### PR TITLE
fix: Python 3.10 compatibility for version test

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 def test_version_matches_pyproject() -> None:
     """Ensure __version__ in __init__.py matches pyproject.toml."""
-    import tomllib
-
     from har_capture import __version__
 
     pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
-    with open(pyproject_path, "rb") as f:
-        pyproject = tomllib.load(f)
+    pyproject_text = pyproject_path.read_text()
 
-    pyproject_version = pyproject["project"]["version"]
+    # Parse version from pyproject.toml using regex (avoids tomllib/tomli dependency)
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE)
+    assert match, "Could not find version in pyproject.toml"
+    pyproject_version = match.group(1)
 
     assert __version__ == pyproject_version, (
-        f"Version mismatch: __init__.py has {__version__!r}, "
-        f"pyproject.toml has {pyproject_version!r}"
+        f"Version mismatch: __init__.py has {__version__!r}, pyproject.toml has {pyproject_version!r}"
     )


### PR DESCRIPTION
## Summary
- Use regex to parse version from pyproject.toml instead of `tomllib`
- `tomllib` is only available in Python 3.11+, breaking tests on 3.10

## Test plan
- [x] CI passes on Python 3.10, 3.11, 3.12, 3.13
- [x] Version consistency test still catches mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)