### PR TITLE
feat: pretty-print HAR files by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.2.2"
+version = "0.2.3"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/capture/browser.py
+++ b/src/har_capture/capture/browser.py
@@ -167,9 +167,9 @@ def filter_and_compress_har(
     har["log"]["entries"] = filtered_entries
     filtered_count = len(filtered_entries)
 
-    # Write filtered HAR
+    # Write filtered HAR (pretty-printed for readability)
     with open(har_path, "w", encoding="utf-8") as f:
-        json.dump(har, f, separators=(",", ":"))  # Compact JSON
+        json.dump(har, f, indent=2)
 
     filtered_size = har_path.stat().st_size
 


### PR DESCRIPTION
## Summary
- HAR files are now written with `indent=2` for better readability
- Compressed output size is nearly identical (whitespace compresses well)
- Easier to inspect/debug HAR files in text editors

## Test plan
- [x] Existing tests pass
- [x] Version bumped to 0.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)