### PR TITLE
fix(capture): missing response bodies, serial false positives — v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-04-08
+
+### Fixed
+
+- **Missing response body on initial page load** — Playwright's HAR recorder fetches bodies lazily at `context.close()` via CDP `Network.getResponseBody`. If a navigation (e.g., form POST) evicts the response from Chrome's buffer before the flush, the body is lost — headers and sizes are correct but `content.text` is absent. Added eager body capture via `page.on("response")` for text content types and a post-capture `_patch_missing_bodies()` step that fills missing bodies from the cache before sanitization.
+- **Serial number false positives** — Reduced false positive serial number detections in sanitization. Improved JS variable name detection and pipe-delimited pattern testability.
+
+### Removed
+
+- **No-op route handler** — Removed `context.route("**/*", lambda route: route.continue_())` which enabled the CDP Fetch domain unnecessarily, potentially interfering with HAR body capture.
+
 ## [0.6.0] - 2026-04-06
 
 ### Changed
@@ -464,4 +475,5 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.5.0]: https://github.com/solentlabs/har-capture/compare/v0.4.5...v0.5.0
 [0.5.1]: https://github.com/solentlabs/har-capture/compare/v0.5.0...v0.5.1
 [0.6.0]: https://github.com/solentlabs/har-capture/compare/v0.5.1...v0.6.0
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.6.0...HEAD
+[0.6.1]: https://github.com/solentlabs/har-capture/compare/v0.6.0...v0.6.1
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.6.1...HEAD

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,6 +175,8 @@ The pattern system is how har-capture stays domain-agnostic while supporting dom
 
 This means a consumer like cable_modem_monitor ships its own pattern file and gets domain-tuned sanitization without har-capture carrying any modem-specific code. Consumers can layer multiple `--patterns` arguments for incremental customization.
 
+**Confidence boundary:** Domain `pii.patterns` entries run as Pass 0 auto-redaction — they must have 100% confidence (zero false positives). Domain `heuristics.detectors` entries flag values for interactive review and can tolerate lower confidence. When a domain-specific pattern cannot guarantee zero false positives, it belongs in `heuristics.detectors`, not `pii.patterns`.
+
 See [Pattern Spec](specs/PATTERN_SPEC.md) for file schemas, merge semantics, and the loader/cache architecture.
 
 ## Functional Specs

--- a/docs/specs/CAPTURE_SPEC.md
+++ b/docs/specs/CAPTURE_SPEC.md
@@ -159,13 +159,14 @@ Controls the `wait_until` argument to Playwright's `page.goto()`. Accepts any Pl
 
 ### Internal Decomposition
 
-`capture_device_har()` is the public API — its signature is unchanged. Internally, it delegates to four extracted functions that can each be tested independently:
+`capture_device_har()` is the public API — its signature is unchanged. Internally, it delegates to five extracted functions that can each be tested independently:
 
 ```
 capture_device_har()
 ├── Pre-flight checks (check_playwright, check_browser_installed)
 ├── _resolve_capture_paths()   → CapturePathInfo
 ├── _run_browser_session()     → BrowserSessionResult
+├── _patch_missing_bodies()    → patches temp HAR in-place
 ├── _inject_har_metadata()     → modifies temp HAR in-place
 └── _run_post_capture_pipeline() → CaptureResult
 ```
@@ -256,6 +257,7 @@ class BrowserSessionResult:
     browser_cookies: list[Any]               # Cookies after page load
     web_storage_local: list[dict[str, Any]]  # localStorage entries per origin
     web_storage_session: dict[str, str]      # sessionStorage key/value pairs
+    captured_bodies: dict[str, bytes]        # Eagerly captured response bodies
     success: bool
     error: str | None
 ```
@@ -397,7 +399,33 @@ This is more robust than Playwright's `networkidle` (500ms) — it waits for `_D
 
 #### `--no-wait-for-data` Behavior
 
-When disabled, no JS injection, no quiescence polling, and no `framenavigated` listener. A context-level route (`context.route("**/*", ...)`) still handles cache control. `page.goto()` with `wait_until="networkidle"` is the only wait mechanism.
+When disabled, no JS injection, no quiescence polling, and no `framenavigated` listener. `page.goto()` with `wait_until="networkidle"` is the only wait mechanism. The eager response body capture listener (`page.on("response")`) is always active regardless of this flag.
+
+### Eager Response Body Capture
+
+#### Problem
+
+Playwright's `record_har_content="embed"` captures response bodies lazily — it calls CDP `Network.getResponseBody` when `context.close()` flushes the HAR to disk. If a navigation event causes Chrome to evict the response data from its network buffer before the flush, the body is lost. Headers, sizes, and timing are correct (captured synchronously from Network domain events), but `content.text` is absent and `content.size` is `-1`.
+
+This typically affects the initial page load (e.g., a login form) when the user or JavaScript submits a form quickly, triggering a navigation that supersedes the first response.
+
+#### Solution: Eager Body Capture via Response Listener
+
+Before navigation, a `page.on("response")` listener is registered that eagerly calls `response.body()` for text-based content types (`text/*`, `application/json`, `application/xml`). Bodies are stored in `BrowserSessionResult.captured_bodies` keyed by `"<method>|<url>|<status>"`.
+
+After Playwright writes the HAR and before metadata injection, `_patch_missing_bodies()` scans HAR entries for responses that have `bodySize > 0` or `_transferSize > 0` but no `content.text`. For each missing body, it looks up the key in the captured bodies cache and patches the body into the HAR entry.
+
+Text bodies are stored as plain UTF-8 strings. Non-UTF-8 bodies fall back to base64 encoding with `content.encoding = "base64"`.
+
+#### `_patch_missing_bodies(temp_path, captured_bodies) -> int`
+
+- Reads the raw HAR from `temp_path`
+- For each entry missing `content.text` with `bodySize > 0` or `_transferSize > 0`: looks up `"<method>|<url>|<status>"` in `captured_bodies` and patches the body
+- Writes the patched HAR back to `temp_path`
+- Returns the number of entries patched
+- Handles corrupt HAR files gracefully (returns 0)
+
+Testable with: zero mocks (real temp file).
 
 ### Timeout vs Interactive Mode
 
@@ -459,9 +487,13 @@ Error messages are sanitized via `_sanitize_error_message()` to remove any embed
 
 ## Post-Capture Processing
 
+### Body Patching
+
+Immediately after the browser closes and writes the raw HAR, `_patch_missing_bodies()` scans for entries with missing response bodies and patches them from the eagerly captured body cache. This runs before metadata injection and sanitization so that downstream processing sees complete responses.
+
 ### Metadata Injection
 
-After the browser closes and writes the raw HAR:
+After body patching:
 
 ```python
 har_data["log"]["_probes"] = probes_data

--- a/docs/specs/PATTERN_SPEC.md
+++ b/docs/specs/PATTERN_SPEC.md
@@ -306,7 +306,15 @@ Examples for `network-device`: `qam256`, `atdma`, `bpi+`, `honor mdd`, `dhcpclie
 
 ### Section: `pii.patterns`
 
-Additional PII detection patterns. Same schema as `pii.json` `patterns` entries.
+Additional PII patterns for deterministic auto-redaction (Pass 0 of the HTML scanner). Same schema as `pii.json` `patterns` entries.
+
+**Confidence requirement:** Every pattern runs as auto-redact — the matched value is replaced without user review. Patterns MUST achieve 100% confidence. If a pattern cannot meet this bar, use `heuristics.detectors` instead.
+
+| Criterion      | `pii.patterns`              | `heuristics.detectors`      |
+| -------------- | --------------------------- | --------------------------- |
+| Confidence     | 100% — zero false positives | Lower confidence acceptable |
+| Action         | Auto-redact (irreversible)  | Flag for user review        |
+| Pipeline stage | Pass 0 (scanner)            | Heuristic engine            |
 
 ### Built-in Domain: `network_device.json`
 

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -209,30 +209,33 @@ MIME-type based routing:
 
 The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 in the code, with sub-passes like 0b, 2b, 7a/7b, 8b). Each pass uses regex substitution with callback functions that invoke the hasher.
 
-| Pass | Scanner                       | Pattern                                         | Redaction                              |
-| ---- | ----------------------------- | ----------------------------------------------- | -------------------------------------- |
-| 0    | Custom patterns               | Domain-specific PII regex                       | Per-pattern prefix                     |
-| 0b   | Web storage                   | `localStorage.setItem('KEY', 'VALUE')`          | Auto-redact if key is sensitive        |
-| 1    | MAC addresses                 | `([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}`         | `hasher.hash_mac()`                    |
-| 2    | Serial numbers (inline)       | `SN\|S/N\|Serial Number` + value                | `hasher.hash_value(val, "SERIAL")`     |
-| 2b   | Serial numbers (table)        | `<td>Label</td><td>VALUE</td>`                  | `hasher.hash_value(val, "SERIAL")`     |
-| 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value | `hasher.hash_value(val, "ACCOUNT")`    |
-| 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)         | `hasher.hash_ip(ip, is_private=True)`  |
-| 5    | Public IPs                    | Non-private, non-reserved                       | `hasher.hash_ip(ip, is_private=False)` |
-| 6    | IPv6 addresses                | Full + compressed, validated via `ipaddress`    | `hasher.hash_ipv6()`                   |
-| 7    | Passwords/passphrases         | `password=value`, `passphrase=value`            | `hasher.hash_value(val, "PASS")`       |
-| 7a   | SSID text labels              | SSID labels in HTML text nodes                  | `hasher.hash_value(val, "WIFI")`       |
-| 7b   | JS password objects           | JavaScript object password fields               | `hasher.hash_value(val, "PASS")`       |
-| 8    | Password inputs               | `<input type="password" value="...">`           | `hasher.hash_value(val, "PASS")`       |
-| 8b   | SSID inputs                   | SSID-related input fields                       | `hasher.hash_value(val, "WIFI")`       |
-| 9    | Session tokens                | 20+ char alphanumeric with label prefix         | `hasher.hash_value(val, "TOKEN")`      |
-| 10   | CSRF tokens                   | CSRF tokens in meta tags                        | `hasher.hash_value(val, "CSRF")`       |
-| 11   | Email addresses               | `user+tag@sub.domain.co.uk`                     | `hasher.hash_email()`                  |
-| 12   | Config paths                  | `.cfg` file references                          | `hasher.hash_value(val, "CONFIG")`     |
-| 13   | Vendor JS vars                | Motorola `var CurrentPw_24g = '...'`            | `hasher.hash_value(val, "PASS")`       |
-| 14   | Pipe-delimited (tagValueList) | `var name = "val1\|val2\|val3"`                 | Per-value heuristic analysis           |
-| 15   | Pipe-delimited (other)        | Other pipe-delimited variables                  | Per-value heuristic analysis           |
-| 16   | SSID fields in JS             | `ssid_24g: 'value'`, `guest_ssid: 'value'`      | `hasher.hash_value(val, "WIFI")`       |
+| Pass | Scanner                       | Pattern                                             | Redaction                              |
+| ---- | ----------------------------- | --------------------------------------------------- | -------------------------------------- |
+| 0    | Custom patterns               | Domain-specific PII regex                           | Per-pattern prefix                     |
+| 0b   | Web storage                   | `localStorage.setItem('KEY', 'VALUE')`              | Auto-redact if key is sensitive        |
+| 1    | MAC addresses                 | `([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}`             | `hasher.hash_mac()`                    |
+| 2    | Serial numbers (inline)       | `\bSN\b\|S/N\|Serial Number` + value                | `hasher.hash_value(val, "SERIAL")`     |
+| 2b   | Serial numbers (table)        | `<td>Label\b</td><td>VALUE</td>`                    | `hasher.hash_value(val, "SERIAL")`     |
+| 2c   | JS serial variables           | Names with serial+Number/Num/No or ending in serial | `hasher.hash_value(val, "SERIAL")`     |
+| 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value     | `hasher.hash_value(val, "ACCOUNT")`    |
+| 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)             | `hasher.hash_ip(ip, is_private=True)`  |
+| 5    | Public IPs                    | Non-private, non-reserved                           | `hasher.hash_ip(ip, is_private=False)` |
+| 6    | IPv6 addresses                | Full + compressed, validated via `ipaddress`        | `hasher.hash_ipv6()`                   |
+| 7    | Passwords/passphrases         | `password=value`, `passphrase=value`                | `hasher.hash_value(val, "PASS")`       |
+| 7a   | SSID text labels              | SSID labels in HTML text nodes                      | `hasher.hash_value(val, "WIFI")`       |
+| 7b   | JS password objects           | JavaScript object password fields                   | `hasher.hash_value(val, "PASS")`       |
+| 8    | Password inputs               | `<input type="password" value="...">`               | `hasher.hash_value(val, "PASS")`       |
+| 8b   | SSID inputs                   | SSID-related input fields                           | `hasher.hash_value(val, "WIFI")`       |
+| 9    | Session tokens                | 20+ char alphanumeric with label prefix             | `hasher.hash_value(val, "TOKEN")`      |
+| 10   | CSRF tokens                   | CSRF tokens in meta tags                            | `hasher.hash_value(val, "CSRF")`       |
+| 11   | Email addresses               | `user+tag@sub.domain.co.uk`                         | `hasher.hash_email()`                  |
+| 12   | Config paths                  | `.cfg` file references                              | `hasher.hash_value(val, "CONFIG")`     |
+| 13   | Vendor JS vars                | Motorola `var CurrentPw_24g = '...'`                | `hasher.hash_value(val, "PASS")`       |
+| 14   | Pipe-delimited (tagValueList) | `var name = "val1\|val2\|val3"`                     | Per-value heuristic analysis           |
+| 15   | Pipe-delimited (other)        | Other pipe-delimited variables                      | Per-value heuristic analysis           |
+| 16   | SSID fields in JS             | `ssid_24g: 'value'`, `guest_ssid: 'value'`          | `hasher.hash_value(val, "WIFI")`       |
+
+**Pass 2c precision rule:** Matches variable names containing the compound `serial` + `number`/`num`/`no` (with optional separator), and names ending with `serial`. Does NOT match `serial` followed by unrelated suffixes (`Protocol`, `Port`, `Baud`, `ization`). Bare `serial` is excluded — too ambiguous for auto-redact.
 
 ### Web Storage Scanner (Pass 0b)
 
@@ -551,3 +554,4 @@ Detects common redaction markers to warn users before double-sanitizing.
 1. **Cookie metadata is preserved** — Cookie attributes (HttpOnly, Secure, SameSite, Path, Domain, Expires) are detected and not redacted. Only cookie values are redacted.
 1. **Credit card detection requires Luhn** — A 16-digit number is only redacted as a credit card if it passes Luhn checksum validation.
 1. **Global find-replace in Pass 2** — User-selected redactions are applied via string replacement on the serialized JSON, ensuring all occurrences (headers, body, URLs) are caught.
+1. **Scanner passes require 100% confidence** — Every regex in the HTML scanner pipeline (passes 0–16) auto-redacts without user review. A pattern that produces false positives is a bug. Patterns that cannot achieve 100% confidence belong in the heuristic engine (flagged for user review), not the scanner pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.6.0"
+version = "0.6.1"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/capture/browser.py
+++ b/src/har_capture/capture/browser.py
@@ -6,6 +6,7 @@ Requires the 'capture' optional dependency: pip install har-capture[capture]
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import dataclasses
 import gzip
@@ -258,6 +259,9 @@ class BrowserSessionResult:
         browser_cookies: Cookies after page load (JS-set included)
         web_storage_local: localStorage entries per origin
         web_storage_session: sessionStorage key/value pairs
+        captured_bodies: Eagerly captured response bodies keyed by
+            ``"<method>|<url>|<status>"`` — used to patch HAR entries
+            whose bodies were evicted before Playwright flushed the HAR.
         success: True if the session completed without error
         error: Error message if session failed
     """
@@ -266,6 +270,7 @@ class BrowserSessionResult:
     browser_cookies: list[Any] = dataclasses.field(default_factory=list)
     web_storage_local: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     web_storage_session: dict[str, str] = dataclasses.field(default_factory=dict)
+    captured_bodies: dict[str, bytes] = dataclasses.field(default_factory=dict)
     success: bool = True
     error: str | None = None
 
@@ -536,7 +541,25 @@ def _run_browser_session(
 
             page.on("framenavigated", _on_frame_navigated)
 
-        context.route("**/*", lambda route: route.continue_())
+        # Eagerly capture response bodies for text content types.
+        # Playwright's HAR recorder fetches bodies lazily at context.close()
+        # via CDP Network.getResponseBody.  If a navigation evicts the
+        # response from Chrome's buffer before the flush, the body is lost.
+        # Capturing here while the response is still live lets us patch
+        # missing bodies into the HAR afterward.
+        def _on_response(response: Any) -> None:
+            try:
+                ct = response.headers.get("content-type", "")
+                if not any(t in ct for t in ("text/", "application/json", "application/xml")):
+                    return
+                body = response.body()
+                if body:
+                    key = f"{response.request.method}|{response.url}|{response.status}"
+                    result.captured_bodies[key] = body
+            except Exception:  # noqa: S110 — response may be aborted/streaming
+                pass
+
+        page.on("response", _on_response)
 
         # Navigate with auto-fallback
         if page_load_strategy == "networkidle":
@@ -607,6 +630,88 @@ def _run_browser_session(
             _LOGGER.warning("Failed to close browser instance: %s", e)
 
     return result
+
+
+def _patch_missing_bodies(
+    temp_path: Path,
+    captured_bodies: dict[str, bytes],
+) -> int:
+    """Patch missing response bodies into the raw HAR.
+
+    Playwright's HAR recorder fetches response bodies lazily at
+    ``context.close()`` via CDP ``Network.getResponseBody``.  If a
+    navigation evicts the response from Chrome's buffer before the
+    flush, the body is lost — headers and sizes are correct but
+    ``content.text`` is absent.
+
+    This function fills the gap using bodies eagerly captured via
+    ``page.on("response")`` during the live session.
+
+    Args:
+        temp_path: Path to the raw HAR temp file (modified in-place).
+        captured_bodies: Map of ``"<method>|<url>|<status>"`` → raw
+            response bytes captured during the browser session.
+
+    Returns:
+        Number of HAR entries whose bodies were patched.
+    """
+    if not captured_bodies:
+        return 0
+
+    try:
+        with open(temp_path, encoding="utf-8") as f:
+            har = json.load(f)
+    except Exception:
+        return 0
+
+    patched = 0
+    for entry in har.get("log", {}).get("entries", []):
+        response = entry.get("response", {})
+        content = response.get("content", {})
+
+        # Skip entries that already have body content
+        if content.get("text"):
+            continue
+
+        # Only patch if the response indicated there was content
+        if response.get("bodySize", 0) <= 0 and response.get("_transferSize", 0) <= 0:
+            continue
+
+        method = entry.get("request", {}).get("method", "GET")
+        url = entry.get("request", {}).get("url", "")
+        status = response.get("status", 0)
+        key = f"{method}|{url}|{status}"
+
+        if key not in captured_bodies:
+            continue
+
+        body = captured_bodies[key]
+        mime = content.get("mimeType", "")
+
+        # Text content types are stored as plain text in the HAR
+        if any(t in mime for t in ("text/", "application/json", "application/xml")):
+            try:
+                content["text"] = body.decode("utf-8")
+            except UnicodeDecodeError:
+                content["text"] = base64.b64encode(body).decode("ascii")
+                content["encoding"] = "base64"
+        else:
+            content["text"] = base64.b64encode(body).decode("ascii")
+            content["encoding"] = "base64"
+
+        content["size"] = len(body)
+        patched += 1
+
+    if patched:
+        _LOGGER.info("Patched %d HAR entries with eagerly captured response bodies", patched)
+        try:
+            with open(temp_path, "w", encoding="utf-8") as f:
+                json.dump(har, f)
+        except Exception as e:
+            _LOGGER.warning("Failed to write patched HAR: %s", e)
+            return 0
+
+    return patched
 
 
 def _inject_har_metadata(
@@ -923,10 +1028,13 @@ def capture_device_har(
                 error=error_str,
             )
 
-    # 3. Inject metadata
+    # 3. Patch any response bodies that Playwright missed
+    _patch_missing_bodies(paths.temp_path, session.captured_bodies)
+
+    # 4. Inject metadata
     _inject_har_metadata(paths.temp_path, paths.target_url, probes, session)
 
-    # 4. Post-capture pipeline
+    # 5. Post-capture pipeline
     return _run_post_capture_pipeline(
         temp_path=paths.temp_path,
         output_path=paths.output_path,

--- a/src/har_capture/patterns/pii.json
+++ b/src/har_capture/patterns/pii.json
@@ -7,7 +7,7 @@
       "description": "MAC addresses in colon or dash format"
     },
     "serial_number": {
-      "regex": "(Serial\\s*Number|SerialNum|SN|S/N)\\s*[:\\s=]*(?:<[^>]*>)*\\s*([a-zA-Z0-9\\-]{5,})",
+      "regex": "(Serial\\s*Number|SerialNum|SN|S/N)\\b\\s*[:\\s=]*(?:<[^>]*>)*\\s*([a-zA-Z0-9\\-]{5,})",
       "replacement_prefix": "SERIAL",
       "flags": ["IGNORECASE"],
       "description": "Device serial numbers with various label formats"

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -47,6 +47,105 @@ else:
 # SNMP-related values like SNMPv3Auth, SNMPCommunityString, etc.
 _PIPE_SERIAL_RE = re.compile(r"^(?:SN|S/N|S-N)[-_][A-Za-z0-9]{5,}$", re.IGNORECASE)
 
+# Already-redacted hash pattern for pipe-delimited values (MAC_a1b2c3d4, SERIAL_deadbeef)
+_ALREADY_REDACTED_HASH_RE = re.compile(r"^[A-Z_]+_[a-f0-9]{8}$")
+
+# MAC address pattern for pipe-delimited values (exact match)
+_PIPE_MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+
+
+def _sanitize_pipe_value(
+    value: str,
+    *,
+    hasher: Hasher,
+    collector: RedactionCollector,
+    safe_values: set[str],
+    extra_safe_patterns: list[re.Pattern[str]],
+    compiled_detectors: list[Any],
+    heuristics: HeuristicMode,
+    values_context: list[str],
+    value_index: int,
+    all_values: list[str] | None = None,
+) -> str:
+    """Process a single pipe-delimited value.
+
+    Returns the sanitized value (hashed), the original value (preserved),
+    or the original value with a side-effect flag recorded in the collector.
+
+    Args:
+        value: Raw value from pipe-delimited string (stripped)
+        hasher: Hasher for correlation-preserving redaction
+        collector: Collector for recording redactions and flags
+        safe_values: Case-insensitive safe value set from tagValueList config
+        extra_safe_patterns: Domain-specific safe value regex patterns
+        compiled_detectors: Domain heuristic detectors
+        heuristics: Heuristic mode (DISABLED, FLAG, REDACT)
+        values_context: Already-processed values (for adjacency detection)
+        value_index: Position in the pipe-delimited string
+        all_values: Full original value list (for FLAG mode context capture)
+
+    Returns:
+        Sanitized or preserved value string
+    """
+    from har_capture.sanitization.heuristics import (
+        analyze_value,
+        is_safe_value,
+    )
+
+    val_lower = value.lower()
+
+    # Skip empty values, safe values, and already-redacted placeholders
+    if not value or is_safe_value(value, extra_safe_patterns):
+        return value
+
+    # Skip already-redacted values (e.g., MAC_xxxxx, MODEM_SN_xxxxx)
+    if value.startswith("***") or _ALREADY_REDACTED_HASH_RE.match(value) or value == "XX:XX:XX:XX:XX:XX":
+        return value
+
+    # Check if value is in safe list
+    if val_lower in safe_values:
+        return value
+
+    # AUTO-REDACT: Known reliable patterns
+    # MAC addresses
+    if _PIPE_MAC_RE.match(value):
+        collector.record_auto_redaction("mac_address")
+        return hasher.hash_mac(value)
+
+    # Serial numbers with SN/S/N prefix
+    if _PIPE_SERIAL_RE.match(value):
+        collector.record_auto_redaction("serial_number")
+        return hasher.hash_generic(value, "SERIAL")
+
+    # HEURISTICS: Analyze unknown values (opt-in)
+    if heuristics != HeuristicMode.DISABLED:
+        should_flag, confidence, category, reason = analyze_value(
+            value,
+            values_context=values_context,
+            value_index=value_index,
+            extra_safe_patterns=extra_safe_patterns,
+            compiled_detectors=compiled_detectors,
+        )
+
+        if should_flag:
+            if heuristics == HeuristicMode.REDACT:
+                collector.record_auto_redaction(category)
+                return hasher.hash_sensitive_value(value, category)
+            if heuristics == HeuristicMode.FLAG:
+                from har_capture.cli.interactive import capture_pipe_context
+
+                context = capture_pipe_context(all_values or [], value_index)
+                collector.flag_value(
+                    value,
+                    category,
+                    confidence,
+                    context,
+                    reason,
+                )
+
+    # Preserve value (either not flagged, or flagged for review)
+    return value
+
 
 def is_valid_ip_address(value: str) -> bool:
     """Check if dotted-decimal string is a valid IPv4 address (not a version string).
@@ -176,10 +275,7 @@ def sanitize_html(
     # Lazy imports — must stay inside function body to avoid circular import
     # (har.py imports html.py at module level; html.py needs har.py's field matcher)
     from har_capture.sanitization.har import is_sensitive_field
-    from har_capture.sanitization.heuristics import (
-        analyze_value,
-        is_safe_value,
-    )
+    from har_capture.sanitization.heuristics import analyze_value
 
     # 0. Custom patterns (apply first so they take precedence over built-in patterns)
     # Skip built-in patterns that have dedicated replacement logic below
@@ -287,7 +383,7 @@ def sanitize_html(
         return f"{label}: {hashed}"
 
     html = re.sub(
-        r"\b(Serial\s*Number|SerialNum|SN|S/N)\s*[:\s=]*(?:<[^>]*>)*\s*([a-zA-Z0-9\-]{5,})",
+        r"\b(Serial\s*Number|SerialNum|SN|S/N)\b\s*[:\s=]*(?:<[^>]*>)*\s*([a-zA-Z0-9\-]{5,})",
         replace_serial,
         html,
         flags=re.IGNORECASE,
@@ -303,8 +399,27 @@ def sanitize_html(
         return f"{prefix}{hashed}"
 
     html = re.sub(
-        r"(<td[^>]*>(?:<[^>]*>)*\s*(?:Serial\s*Number|SerialNum|SN|S/N)\s*(?:<[^>]*>)*\s*</td>\s*<td[^>]*>(?:<[^>]*>)*\s*)([a-zA-Z0-9\-]{5,})(?=\s*(?:<[^>]*>)*\s*</td>)",
+        r"(<td[^>]*>(?:<[^>]*>)*\s*(?:Serial\s*Number|SerialNum|SN|S/N)\b\s*(?:<[^>]*>)*\s*</td>\s*<td[^>]*>(?:<[^>]*>)*\s*)([a-zA-Z0-9\-]{5,})(?=\s*(?:<[^>]*>)*\s*</td>)",
         replace_serial_table,
+        html,
+        flags=re.IGNORECASE,
+    )
+
+    # 2c. JavaScript serial number variables
+    # Matches: names containing serial+number/num/no (e.g., serialNumber, serial_num, SerialNo)
+    # Matches: names ending with "serial" (e.g., deviceSerial, modem_serial)
+    # Does NOT match: serial+Port, serial+Protocol, serial+Baud, serialization, serialized
+    def replace_js_serial(match: re.Match[str]) -> str:
+        collector.record_auto_redaction("serial_number")
+        label = match.group(1)
+        sep = match.group(2)
+        quote1 = match.group(3)
+        quote2 = match.group(5)
+        return f"{label}{sep}{quote1}{hasher.hash_generic(match.group(4), 'SERIAL')}{quote2}"
+
+    html = re.sub(
+        r'(\w*serial[-_]?(?:num(?:ber)?|no)\w*|\w+serial)\s*([=:])\s*(["\'])([^"\']+)(["\'])',
+        replace_js_serial,
         html,
         flags=re.IGNORECASE,
     )
@@ -336,9 +451,9 @@ def sanitize_html(
         ip = match.group(0)
         if ip in preserved_ips:
             return ip
-        # Validate it's actually an IP, not a version string
-        if not is_valid_ip_address(ip):
-            return ip  # Preserve version strings like "5.7.1.5"
+        # Private IP regex only matches 10.x/172.16-31.x/192.168.x — all have
+        # first octets (10, 172, 192) that pass is_valid_ip_address() unconditionally,
+        # so no version-string check is needed here (unlike public IPs in pass 5).
         collector.record_auto_redaction("private_ip")
         return hasher.hash_ip(ip, is_private=True)
 
@@ -541,14 +656,8 @@ def sanitize_html(
     def sanitize_tag_value_list(match: re.Match[str]) -> str:
         """Sanitize pipe-delimited values in tagValueList.
 
-        Always auto-redacts values matching KNOWN patterns (MAC addresses).
-
-        When heuristics are enabled, analyzes remaining values to detect
-        potential PII (WiFi credentials, SSIDs, device names) based on
-        patterns, entropy, and context:
-        - DISABLED: Skip heuristic analysis (default)
-        - FLAG: Flag suspicious values for manual review
-        - REDACT: Auto-redact suspicious values (may over-redact)
+        Splits by ``|``, delegates each value to ``_sanitize_pipe_value()``,
+        and reassembles.
         """
         prefix = match.group(1)
         values_str = match.group(2)
@@ -557,75 +666,20 @@ def sanitize_html(
         values = values_str.split("|")
         sanitized_values: list[str] = []
 
-        for i, val in enumerate(values):
-            val_stripped = val.strip()
-            val_lower = val_stripped.lower()
-
-            # Skip empty values, safe values, and already-redacted placeholders
-            if not val_stripped or is_safe_value(val_stripped, extra_safe_patterns):
-                sanitized_values.append(val)
-                continue
-
-            # Skip already-redacted values (e.g., MAC_xxxxx, MODEM_SN_xxxxx)
-            if (
-                val_stripped.startswith("***")
-                or re.match(r"^[A-Z_]+_[a-f0-9]{8}$", val_stripped)
-                or val_stripped == "XX:XX:XX:XX:XX:XX"
-            ):
-                sanitized_values.append(val)
-                continue
-
-            # Check if value is in safe list
-            if val_lower in safe_values:
-                sanitized_values.append(val)
-                continue
-
-            # AUTO-REDACT: Known reliable patterns
-            # MAC addresses
-            if re.match(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$", val_stripped):
-                collector.record_auto_redaction("mac_address")
-                sanitized_values.append(hasher.hash_mac(val_stripped))
-                continue
-
-            # Serial numbers with SN/S/N prefix
-            if _PIPE_SERIAL_RE.match(val_stripped):
-                collector.record_auto_redaction("serial_number")
-                sanitized_values.append(hasher.hash_generic(val_stripped, "SERIAL"))
-                continue
-
-            # HEURISTICS: Analyze unknown values (opt-in)
-            if heuristics != HeuristicMode.DISABLED:
-                should_flag, confidence, category, reason = analyze_value(
-                    val_stripped,
-                    values_context=sanitized_values,
-                    value_index=len(sanitized_values),
-                    extra_safe_patterns=extra_safe_patterns,
-                    compiled_detectors=compiled_detectors,
-                )
-
-                if should_flag:
-                    if heuristics == HeuristicMode.REDACT:
-                        # Auto-redact the flagged value
-                        redacted = hasher.hash_sensitive_value(val_stripped, category)
-                        sanitized_values.append(redacted)
-                        collector.record_auto_redaction(category)
-                        continue
-                    if heuristics == HeuristicMode.FLAG:
-                        # Flag for review, preserve value
-                        from har_capture.cli.interactive import capture_pipe_context
-
-                        context = capture_pipe_context(values, i)
-                        collector.flag_value(
-                            val_stripped,
-                            category,
-                            confidence,
-                            context,
-                            reason,
-                        )
-                        # Fall through to append original value
-
-            # Preserve value (either not flagged, or flagged for review)
-            sanitized_values.append(val)
+        for val in values:
+            result = _sanitize_pipe_value(
+                val.strip(),
+                hasher=hasher,
+                collector=collector,
+                safe_values=safe_values,
+                extra_safe_patterns=extra_safe_patterns,
+                compiled_detectors=compiled_detectors,
+                heuristics=heuristics,
+                values_context=sanitized_values,
+                value_index=len(sanitized_values),
+                all_values=values,
+            )
+            sanitized_values.append(result)
 
         return prefix + "|".join(sanitized_values) + suffix
 

--- a/tests/fixtures/test_har_processing.json
+++ b/tests/fixtures/test_har_processing.json
@@ -682,5 +682,97 @@
         }
       ]
     }
+  },
+  "har_missing_body": {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "test", "version": "1.0" },
+      "entries": [
+        {
+          "request": { "method": "GET", "url": "http://192.168.100.1/", "headers": [] },
+          "response": {
+            "status": 200,
+            "headers": [
+              { "name": "Content-Length", "value": "611" },
+              { "name": "Content-type", "value": "text/html" }
+            ],
+            "content": { "size": -1, "mimeType": "text/html", "compression": 0 },
+            "bodySize": 611,
+            "_transferSize": 994
+          }
+        }
+      ]
+    }
+  },
+  "har_body_present": {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "test", "version": "1.0" },
+      "entries": [
+        {
+          "request": { "method": "GET", "url": "http://192.168.100.1/", "headers": [] },
+          "response": {
+            "status": 200,
+            "headers": [],
+            "content": { "text": "<html>original</html>", "size": 21, "mimeType": "text/html" },
+            "bodySize": 21
+          }
+        }
+      ]
+    }
+  },
+  "har_missing_body_no_size": {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "test", "version": "1.0" },
+      "entries": [
+        {
+          "request": { "method": "GET", "url": "http://192.168.100.1/empty", "headers": [] },
+          "response": {
+            "status": 204,
+            "headers": [],
+            "content": { "size": 0, "mimeType": "text/html" },
+            "bodySize": 0
+          }
+        }
+      ]
+    }
+  },
+  "har_mixed_bodies": {
+    "log": {
+      "version": "1.2",
+      "creator": { "name": "test", "version": "1.0" },
+      "entries": [
+        {
+          "request": { "method": "GET", "url": "http://192.168.100.1/", "headers": [] },
+          "response": {
+            "status": 200,
+            "headers": [],
+            "content": { "size": -1, "mimeType": "text/html" },
+            "bodySize": 611,
+            "_transferSize": 994
+          }
+        },
+        {
+          "request": { "method": "POST", "url": "http://192.168.100.1/login", "headers": [] },
+          "response": {
+            "status": 200,
+            "headers": [],
+            "content": { "text": "<html>dashboard</html>", "size": 21, "mimeType": "text/html" },
+            "bodySize": 21
+          }
+        },
+        {
+          "request": { "method": "GET", "url": "http://192.168.100.1/api/status", "headers": [] },
+          "response": {
+            "status": 200,
+            "headers": [],
+            "content": { "size": -1, "mimeType": "application/json" },
+            "bodySize": 42,
+            "_transferSize": 42
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/fixtures/test_html.json
+++ b/tests/fixtures/test_html.json
@@ -13,6 +13,7 @@
     {"input_html": "External DNS: 8.8.8.8",                   "removed": "8.8.8.8",               "placeholder": "0.0.0.0",            "id": "public_ip_google"},
     {"input_html": "Server: 1.1.1.1",                         "removed": "1.1.1.1",               "placeholder": "0.0.0.0",            "id": "public_ip_cloudflare"},
     {"input_html": "API: 203.0.113.50",                       "removed": "203.0.113.50",          "placeholder": "0.0.0.0",            "id": "public_ip_test_net"},
+    {"input_html": "Relay: 3.100.200.50",                     "removed": "3.100.200.50",          "placeholder": "0.0.0.0",            "id": "public_ip_low_first_octet"},
     {"input_html": "IPv6: 2001:db8::1",                       "removed": "2001:db8::1",           "placeholder": "::",                 "id": "ipv6_compressed"},
     {"input_html": "IPv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334", "removed": "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "placeholder": "::", "id": "ipv6_full"},
     {"input_html": "Localhost: ::1",                          "removed": "::1",                   "placeholder": "::",                 "id": "ipv6_localhost"},
@@ -22,7 +23,22 @@
     {"input_html": "Contact: admin@example.com",              "removed": "admin@example.com",     "placeholder": "x@x.invalid",        "id": "email_simple"},
     {"input_html": "Email: user.name+tag@domain.co.uk",       "removed": "user.name+tag@domain.co.uk", "placeholder": "x@x.invalid",   "id": "email_complex"},
     {"input_html": "Config File Name: customer123.cfg",       "removed": "customer123.cfg",       "placeholder": "***CONFIG***",       "id": "config_path"},
-    {"input_html": "config file: isp_settings.cfg",           "removed": "isp_settings.cfg",      "placeholder": "***CONFIG***",       "id": "config_lowercase"}
+    {"input_html": "config file: isp_settings.cfg",           "removed": "isp_settings.cfg",      "placeholder": "***CONFIG***",       "id": "config_lowercase"},
+    {"input_html": "Account ID: 12345678",                    "removed": "12345678",              "placeholder": "***ACCOUNT***",      "id": "account_id"},
+    {"input_html": "Subscriber Number: SUB-9876",             "removed": "SUB-9876",              "placeholder": "***ACCOUNT***",      "id": "subscriber_number"},
+    {"input_html": "SSID: HomeNetwork",                       "removed": "HomeNetwork",           "placeholder": "***WIFI***",         "id": "ssid_text_label"},
+    {"input_html": "Network Name=MyWiFi5G",                   "removed": "MyWiFi5G",              "placeholder": "***WIFI***",         "id": "network_name_label"},
+    {"input_html": "password_24g: 'MyP@ssw0rd'",              "removed": "MyP@ssw0rd",            "placeholder": "***PASS***",         "id": "js_password_obj"},
+    {"input_html": "guest_password = \"secretGuest\"",        "removed": "secretGuest",           "placeholder": "***PASS***",         "id": "js_guest_password"},
+    {"input_html": "<input type=\"password\" value=\"s3cret\">","removed": "s3cret",              "placeholder": "***PASS***",         "id": "password_input_field"},
+    {"input_html": "<label>WiFi SSID</label><input value=\"MyHomeNet\">", "removed": "MyHomeNet", "placeholder": "***WIFI***",         "id": "ssid_input_field"},
+    {"input_html": "session=AbcDef1234567890abcdef",          "removed": "AbcDef1234567890abcdef","placeholder": "***TOKEN***",        "id": "session_token"},
+    {"input_html": "auth: xK9mP2qR7sT4wZaBcDeFgHiJ",         "removed": "xK9mP2qR7sT4wZaBcDeFgHiJ","placeholder": "***TOKEN***",     "id": "auth_token_long"},
+    {"input_html": "<meta name=\"csrf-token\" content=\"xsrf_abc123\">", "removed": "xsrf_abc123","placeholder": "***CSRF***",         "id": "csrf_token_meta"},
+    {"input_html": "var CurrentPw = 'motor0laP@ss'",           "removed": "motor0laP@ss",          "placeholder": "***PASS***",         "id": "motorola_password_var"},
+    {"input_html": "var CurrentPassword = 'adminPass1'",      "removed": "adminPass1",            "placeholder": "***PASS***",         "id": "motorola_password_full"},
+    {"input_html": "ssid_24g: 'MyNetwork5G'",                 "removed": "MyNetwork5G",           "placeholder": "***WIFI***",         "id": "ssid_js_field"},
+    {"input_html": "guest_ssid = \"Visitors\"",               "removed": "Visitors",              "placeholder": "***WIFI***",         "id": "guest_ssid_js_field"}
   ],
 
   "preserve_cases": [
@@ -41,7 +57,10 @@
     {"input_html": "var tagValueList = '0|Good||happymango167|test';", "preserved": "happymango167", "id": "wifi_credential_flagged"},
     {"input_html": "var tagValueList = 'status|MySecretWiFi123|data';", "preserved": "MySecretWiFi123", "id": "wifi_ssid_flagged"},
     {"input_html": "Channel: 123",                            "preserved": "123",                   "id": "numeric_channel"},
-    {"input_html": "Version: 1.0.0",                          "preserved": "1.0.0",                 "id": "version_string"}
+    {"input_html": "Version: 1.0.0",                          "preserved": "1.0.0",                 "id": "version_string"},
+    {"input_html": "Build: 2.4.6.100",                        "preserved": "2.4.6.100",             "id": "version_3_small_octets"},
+    {"input_html": "Firmware: 3.4.5.6",                       "preserved": "3.4.5.6",               "id": "version_4_small_octets"},
+    {"input_html": "Account ID: ACCOUNT_a1b2c3d4",           "preserved": "ACCOUNT_a1b2c3d4",     "id": "account_already_redacted"}
   ],
 
   "pii_detection_cases": [
@@ -87,7 +106,51 @@
     {"input_html": "var tagValueList = 'ok|sn-abcdefgh|enabled';",       "should_not_contain": "sn-abcdefgh",    "should_contain": "SERIAL_",  "id": "pipe_serial_lowercase"},
     {"input_html": "var tagValueList = 'ok|S-N-WXYZ98765|good';",          "should_not_contain": "S-N-WXYZ98765",  "should_contain": "SERIAL_",  "id": "pipe_serial_s_dash_n"},
     {"input_html": "var tagValueList = 'SNMP|enabled|good';",             "should_not_contain": null,             "should_contain": null,       "id": "pipe_not_serial_snmp"},
-    {"input_html": "var tagValueList = 'SN-AB|ok';",                      "should_not_contain": null,             "should_contain": null,       "id": "pipe_serial_too_short"}
+    {"input_html": "var tagValueList = 'SN-AB|ok';",                      "should_not_contain": null,             "should_contain": null,       "id": "pipe_serial_too_short"},
+    {"input_html": "var tagValueList = 'ok|AA:BB:CC:DD:EE:FF|good';",   "should_not_contain": "AA:BB:CC:DD:EE:FF","should_contain": null,     "id": "pipe_mac_auto_redact"},
+    {"input_html": "var tagValueList = 'ok|***MAC***|good';",            "should_not_contain": null,             "should_contain": null,       "id": "pipe_already_redacted_stars"},
+    {"input_html": "var tagValueList = 'ok|MAC_a1b2c3d4|good';",        "should_not_contain": null,             "should_contain": null,       "id": "pipe_already_redacted_hash"},
+    {"input_html": "var tagValueList = 'ok|XX:XX:XX:XX:XX:XX|good';",   "should_not_contain": null,             "should_contain": null,       "id": "pipe_already_redacted_placeholder"},
+    {"input_html": "var tagValueList = 'Locked|OK|good';",              "should_not_contain": null,             "should_contain": null,       "id": "pipe_safe_list_values"}
+  ],
+
+  "serial_key_false_positive_cases": [
+    {"input_html": "{\"SNRLevel\":\"33\",\"LockStatus\":\"Locked\"}",                "preserved": "SNRLevel",    "id": "json_key_snrlevel"},
+    {"input_html": "SNMPEnable: true",                                               "preserved": "SNMPEnable",  "id": "snmp_enable"},
+    {"input_html": "SnmpLog: entry1",                                                "preserved": "SnmpLog",     "id": "snmp_log"},
+    {"input_html": "<td>SNRLevel</td><td>33 dB</td>",                               "preserved": "SNRLevel",    "id": "snrlevel_table"},
+    {"input_html": "SN: DEV123456789",                                               "removed": "DEV123456789",  "id": "sn_still_redacts"}
+  ],
+
+  "js_serial_variable_cases": [
+    {"input_html": "var js_SerialNumber = 'AABB12345678';",   "should_not_contain": "AABB12345678",   "should_contain": "SERIAL_",  "id": "js_serial_number_var"},
+    {"input_html": "var serialNum = \"XYZ9876543\";",         "should_not_contain": "XYZ9876543",     "should_contain": "SERIAL_",  "id": "serial_num_var"},
+    {"input_html": "var deviceSerial = 'ARRIS-11223344';",    "should_not_contain": "ARRIS-11223344", "should_contain": "SERIAL_",  "id": "device_serial_var"},
+    {"input_html": "serialNumber: 'TG3442DE-ABC123'",        "should_not_contain": "TG3442DE-ABC123","should_contain": "SERIAL_",  "id": "serial_number_js_obj"},
+    {"input_html": "var serial_number = 'MODEM-987654';",   "should_not_contain": "MODEM-987654",   "should_contain": "SERIAL_",  "id": "serial_underscore_number_var"},
+    {"input_html": "var modem_serial = 'ARRIS-556677';",    "should_not_contain": "ARRIS-556677",   "should_contain": "SERIAL_",  "id": "modem_serial_var"},
+    {"input_html": "serialNo: 'SB8200-AABB1234'",           "should_not_contain": "SB8200-AABB1234","should_contain": "SERIAL_",  "id": "serial_no_js_obj"},
+    {"input_html": "var serialProtocol = 'RS232';",          "should_not_contain": null,             "should_contain": null,       "id": "serial_protocol_preserved"},
+    {"input_html": "var serialPort = '9600';",               "should_not_contain": null,             "should_contain": null,       "id": "serial_port_preserved"},
+    {"input_html": "var serialBaud = '115200';",             "should_not_contain": null,             "should_contain": null,       "id": "serial_baud_preserved"},
+    {"input_html": "var serialization = 'json';",            "should_not_contain": null,             "should_contain": null,       "id": "serialization_preserved"}
+  ],
+
+  "pipe_value_unit_cases": [
+    {"value": "",                     "expected_unchanged": true,  "id": "empty_value"},
+    {"value": "***MAC***",            "expected_unchanged": true,  "id": "already_redacted_stars"},
+    {"value": "MAC_a1b2c3d4",        "expected_unchanged": true,  "id": "already_redacted_hash"},
+    {"value": "XX:XX:XX:XX:XX:XX",   "expected_unchanged": true,  "id": "already_redacted_placeholder"},
+    {"value": "SERIAL_deadbeef",     "expected_unchanged": true,  "id": "already_redacted_serial_hash"},
+    {"value": "good",                "expected_unchanged": true,  "id": "safe_list_value"},
+    {"value": "locked",              "expected_unchanged": true,  "id": "safe_list_locked"},
+    {"value": "retail",              "expected_unchanged": true,  "id": "safe_list_retail"},
+    {"value": "AA:BB:CC:DD:EE:FF",  "expected_unchanged": true,  "id": "mac_safe_hex_colon_pattern"},
+    {"value": "SN-ABC12345",        "expected_unchanged": false, "expected_contains": "SERIAL_", "id": "serial_auto_redact"},
+    {"value": "S/N-DEVICE789",      "expected_unchanged": false, "expected_contains": "SERIAL_", "id": "serial_s_n_prefix"},
+    {"value": "Locked",             "expected_unchanged": true,  "id": "status_word_safe"},
+    {"value": "OK",                 "expected_unchanged": true,  "id": "status_ok_safe"},
+    {"value": "QAM256",             "expected_unchanged": true,  "id": "modulation_safe"}
   ],
 
   "expected_patterns": [

--- a/tests/test_capture/test_browser.py
+++ b/tests/test_capture/test_browser.py
@@ -1489,10 +1489,14 @@ class TestWaitForData:
         else:
             mock_page.add_init_script.assert_not_called()
 
-        # Both cases use context.route for cache control
-        mock_context.route.assert_called_once()
+        # No context.route — removed to avoid CDP Fetch domain
+        # interfering with HAR body capture
+        mock_context.route.assert_not_called()
         # page.route must never be used (sync API deadlock)
         mock_page.route.assert_not_called()
+
+        # Eager body capture listener is always registered
+        mock_page.on.assert_any_call("response", unittest.mock.ANY)
 
         if expect_nav_listener:
             mock_page.on.assert_any_call("framenavigated", unittest.mock.ANY)

--- a/tests/test_capture/test_har_processing.py
+++ b/tests/test_capture/test_har_processing.py
@@ -1,4 +1,4 @@
-"""Tests for HAR processing functions (filter, compress, metadata)."""
+"""Tests for HAR processing functions (filter, compress, metadata, body patching)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ import pytest
 from har_capture.capture.browser import (
     CaptureOptions,
     _add_capture_metadata,
+    _patch_missing_bodies,
     filter_and_compress_har,
 )
 
@@ -314,3 +315,139 @@ class TestFilterAndCompressHar:
             har = json.load(f)
 
         assert "_probes" not in har["log"]
+
+
+# =============================================================================
+# Body patching
+# =============================================================================
+
+# ┌─────────────────────────┬───────────────────────┬──────────────┬──────────┐
+# │ fixture_key             │ captured_bodies       │ expect_patch │ id       │
+# ├─────────────────────────┼───────────────────────┼──────────────┼──────────┤
+PATCH_BODIES_CASES = [
+    (
+        "har_missing_body",
+        {"GET|http://192.168.100.1/|200": b"<html><input type='hidden' name='csrf'/></html>"},
+        True,
+        "missing_body_patched_from_cache",
+    ),
+    (
+        "har_body_present",
+        {"GET|http://192.168.100.1/|200": b"<html>SHOULD NOT REPLACE</html>"},
+        False,
+        "existing_body_not_overwritten",
+    ),
+    (
+        "har_missing_body",
+        {},
+        False,
+        "empty_cache_no_patch",
+    ),
+    (
+        "har_missing_body",
+        {"GET|http://192.168.100.1/WRONG|200": b"wrong url"},
+        False,
+        "cache_miss_no_patch",
+    ),
+    (
+        "har_missing_body_no_size",
+        {"GET|http://192.168.100.1/empty|204": b""},
+        False,
+        "zero_bodysize_not_patched",
+    ),
+]
+# └─────────────────────────┴───────────────────────┴──────────────┴──────────┘
+
+
+class TestPatchMissingBodies:
+    """Tests for _patch_missing_bodies function."""
+
+    @pytest.mark.parametrize(
+        ("fixture_key", "captured_bodies", "expect_patch", "desc"),
+        PATCH_BODIES_CASES,
+        ids=[c[3] for c in PATCH_BODIES_CASES],
+    )
+    def test_patch_decision(
+        self,
+        tmp_path: Path,
+        fixture_key: str,
+        captured_bodies: dict[str, bytes],
+        expect_patch: bool,
+        desc: str,
+    ) -> None:
+        """Table-driven: verify when bodies are/aren't patched."""
+        har_file = _write_har(tmp_path, fixture_key, "test.har")
+
+        patched_count = _patch_missing_bodies(har_file, captured_bodies)
+
+        assert (patched_count > 0) == expect_patch
+
+        if expect_patch:
+            with open(har_file) as f:
+                har = json.load(f)
+            entry = har["log"]["entries"][0]
+            assert entry["response"]["content"]["text"]
+            assert entry["response"]["content"]["size"] > 0
+
+    def test_patches_correct_body_text(self, tmp_path: Path) -> None:
+        """Verify the patched body matches the eagerly captured content."""
+        har_file = _write_har(tmp_path, "har_missing_body", "test.har")
+        html = "<html><input type='hidden' name='csrf' value='abc'/></html>"
+        bodies = {"GET|http://192.168.100.1/|200": html.encode("utf-8")}
+
+        _patch_missing_bodies(har_file, bodies)
+
+        with open(har_file) as f:
+            har = json.load(f)
+        content = har["log"]["entries"][0]["response"]["content"]
+        assert content["text"] == html
+        assert content["size"] == len(html.encode("utf-8"))
+        assert "encoding" not in content  # UTF-8 text, no base64
+
+    def test_mixed_entries_only_missing_patched(self, tmp_path: Path) -> None:
+        """In a HAR with mixed entries, only missing bodies get patched."""
+        har_file = _write_har(tmp_path, "har_mixed_bodies", "test.har")
+        bodies = {
+            "GET|http://192.168.100.1/|200": b"<html>login</html>",
+            "GET|http://192.168.100.1/api/status|200": b'{"status":"ok"}',
+        }
+
+        patched_count = _patch_missing_bodies(har_file, bodies)
+
+        assert patched_count == 2
+
+        with open(har_file) as f:
+            har = json.load(f)
+
+        entries = har["log"]["entries"]
+        # Entry 0: was missing, now patched
+        assert entries[0]["response"]["content"]["text"] == "<html>login</html>"
+        # Entry 1: already had body, unchanged
+        assert entries[1]["response"]["content"]["text"] == "<html>dashboard</html>"
+        # Entry 2: was missing, now patched
+        assert entries[2]["response"]["content"]["text"] == '{"status":"ok"}'
+
+    def test_non_utf8_body_uses_base64(self, tmp_path: Path) -> None:
+        """Non-UTF-8 text body falls back to base64 encoding."""
+        har_file = _write_har(tmp_path, "har_missing_body", "test.har")
+        body = b"\xff\xfe<html>latin1</html>"
+        bodies = {"GET|http://192.168.100.1/|200": body}
+
+        _patch_missing_bodies(har_file, bodies)
+
+        with open(har_file) as f:
+            har = json.load(f)
+        content = har["log"]["entries"][0]["response"]["content"]
+        assert content["encoding"] == "base64"
+        import base64
+
+        assert base64.b64decode(content["text"]) == body
+
+    def test_corrupt_har_returns_zero(self, tmp_path: Path) -> None:
+        """Corrupt HAR file returns 0 patched without crashing."""
+        har_file = tmp_path / "bad.har"
+        har_file.write_text("not json")
+
+        result = _patch_missing_bodies(har_file, {"GET|http://x/|200": b"body"})
+
+        assert result == 0

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -77,6 +77,16 @@ PIPE_SERIAL_CASES = [
     for c in _FIXTURE["pipe_serial_cases"]
 ]
 
+SERIAL_KEY_FP_CASES = [
+    (c["input_html"], c.get("preserved"), c.get("removed"), c["id"])
+    for c in _FIXTURE["serial_key_false_positive_cases"]
+]
+
+JS_SERIAL_VAR_CASES = [
+    (c["input_html"], c.get("should_not_contain"), c.get("should_contain"), c["id"])
+    for c in _FIXTURE["js_serial_variable_cases"]
+]
+
 
 # =============================================================================
 # Test Classes
@@ -330,6 +340,142 @@ class TestPipeSerialNumber:
                 assert "SNMP" in result, f"{desc}: SNMP should be preserved"
             elif "SN-AB" in html:
                 assert "SN-AB" in result, f"{desc}: short value should be preserved"
+
+
+# =============================================================================
+# Serial Number Key False Positives (SNRLevel, SNMPEnable, etc.)
+# =============================================================================
+
+
+class TestSerialKeyFalsePositives:
+    """Tests that SN-prefix identifiers like SNRLevel are not mangled."""
+
+    @pytest.mark.parametrize(
+        ("html", "preserved", "removed", "desc"),
+        SERIAL_KEY_FP_CASES,
+        ids=[c[3] for c in SERIAL_KEY_FP_CASES],
+    )
+    def test_serial_key_false_positive(
+        self,
+        html: str,
+        preserved: str | None,
+        removed: str | None,
+        desc: str,
+    ) -> None:
+        """Test camelCase/PascalCase SN-prefix identifiers are not rewritten."""
+        result = sanitize_html(html, salt="test")
+        if preserved:
+            assert preserved in result, f"{desc}: '{preserved}' should be preserved"
+        if removed:
+            assert removed not in result, f"{desc}: '{removed}' should be redacted"
+
+
+# =============================================================================
+# JavaScript Serial Number Variable Assignments
+# =============================================================================
+
+
+class TestJsSerialVariable:
+    """Tests for JS variable assignments containing serial number indicators."""
+
+    @pytest.mark.parametrize(
+        ("html", "should_not_contain", "should_contain", "desc"),
+        JS_SERIAL_VAR_CASES,
+        ids=[c[3] for c in JS_SERIAL_VAR_CASES],
+    )
+    def test_js_serial_variable_redaction(
+        self,
+        html: str,
+        should_not_contain: str | None,
+        should_contain: str | None,
+        desc: str,
+    ) -> None:
+        """Test serial number values in JS variable assignments are redacted."""
+        result = sanitize_html(html, salt="test")
+        if should_not_contain:
+            assert should_not_contain not in result, f"{desc}: value should be redacted"
+        if should_contain:
+            assert should_contain in result, f"{desc}: expected prefix in output"
+        if should_not_contain is None:
+            assert result == html, f"{desc}: value should be preserved unchanged"
+
+
+# =============================================================================
+# Pipe-Delimited Per-Value Unit Tests (extracted _sanitize_pipe_value)
+# =============================================================================
+
+PIPE_VALUE_UNIT_CASES = [
+    (c["value"], c["expected_unchanged"], c.get("expected_not_contain"), c.get("expected_contains"), c["id"])
+    for c in _FIXTURE["pipe_value_unit_cases"]
+]
+
+
+class TestSanitizePipeValue:
+    """Unit tests for _sanitize_pipe_value() — the extracted per-value processor."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_unchanged", "expected_not_contain", "expected_contains", "desc"),
+        PIPE_VALUE_UNIT_CASES,
+        ids=[c[4] for c in PIPE_VALUE_UNIT_CASES],
+    )
+    def test_pipe_value_processing(
+        self,
+        value: str,
+        expected_unchanged: bool,
+        expected_not_contain: str | None,
+        expected_contains: str | None,
+        desc: str,
+    ) -> None:
+        """Test individual pipe value sanitization decisions."""
+        from har_capture.patterns import Hasher
+        from har_capture.sanitization.collector import RedactionCollector
+        from har_capture.sanitization.html import _sanitize_pipe_value
+        from har_capture.sanitization.report import HeuristicMode
+
+        hasher = Hasher.create("test")
+        collector = RedactionCollector(hasher=hasher)
+        safe_values = {
+            "good",
+            "locked",
+            "not locked",
+            "unknown",
+            "operational",
+            "ok",
+            "none",
+            "&nbsp;",
+            "enabled",
+            "disabled",
+            "retail",
+            "success",
+            "primary",
+            "enable",
+            "off",
+            "on",
+            "both",
+            "in progress",
+            "synchronized",
+            "not synchronized",
+            "done",
+        }
+
+        result = _sanitize_pipe_value(
+            value,
+            hasher=hasher,
+            collector=collector,
+            safe_values=safe_values,
+            extra_safe_patterns=[],
+            compiled_detectors=[],
+            heuristics=HeuristicMode.DISABLED,
+            values_context=[],
+            value_index=0,
+        )
+
+        if expected_unchanged:
+            assert result == value, f"{desc}: value should be preserved"
+        if expected_not_contain:
+            assert expected_not_contain not in result, f"{desc}: original should be removed"
+        if expected_contains:
+            assert expected_contains in result, f"{desc}: expected prefix in output"
 
 
 class TestCustomPiiPatternEdgeCases:


### PR DESCRIPTION
## Summary

- **Missing response body on initial page load** — Playwright's HAR recorder fetches bodies lazily at `context.close()`. If a navigation evicts the response from Chrome's buffer before flush, the body is lost. Added eager body capture via `page.on("response")` and a `_patch_missing_bodies()` post-capture step that fills missing bodies from the cache.
- **Removed no-op route handler** — `context.route("**/*", lambda route: route.continue_())` enabled the CDP Fetch domain unnecessarily, potentially interfering with HAR body capture.
- **Serial number false positives** — Reduced false positive serial detections, improved JS variable name detection and pipe-delimited pattern testability.
- Version bump to **0.6.1**, changelog updated.

## Test plan

- [x] 1783 tests pass, 85% coverage
- [x] 9 new `TestPatchMissingBodies` tests (table-driven + edge cases)
- [x] Updated `TestWaitForData` assertions (no `context.route`, `page.on("response")` registered)
- [x] Pre-commit hooks pass (ruff, mypy, secrets, mdformat)
- [x] Pre-push CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)