### PR TITLE
feat(sanitization): per-call custom_patterns field-name extension (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sanitize_post_data(..., custom_patterns=...)` now extends field detection** — The `custom_patterns` kwarg (file path or dict matching the `load_sensitive_patterns` schema, e.g. `{"fields": {"auto_redact_patterns": ["pws"]}}`) additively extends the auto-redact and flag regex sets for the call across form params, `application/x-www-form-urlencoded` bodies, JSON bodies, and XML bodies. Previously the kwarg was accepted but field-name detection always used the module-global patterns. The override is plumbed through a `ContextVar`-scoped resolver, so it is thread- and asyncio-safe by construction and does not mutate module state. Compiled regex pairs are cached per canonical key so repeated calls with the same extension skip the compile. Enables downstream consumers (e.g., Cable Modem Monitor) to redact device-specific credential field names without modifying the universal `sensitive.json`.
+
+### Fixed
+
+- **`sanitize_html(..., custom_patterns=...)` now reaches the inline-script field matcher** — The `custom_patterns` kwarg previously loaded custom PII and sensitive patterns but the inline `localStorage.setItem` / `sessionStorage.setItem` scanner still consulted the module-global field regex, so custom field-name extensions silently failed. The HTML body now runs inside the same `ContextVar`-scoped override used by `sanitize_post_data`, so calls like `sanitize_html(html, custom_patterns={"fields": {"auto_redact_patterns": ["pws"]}})` correctly redact values associated with the extended field names.
+- **`load_sensitive_patterns` dict merge for `auto_redact_patterns` / `flag_patterns`** — Passing a custom-patterns dict of the current schema (`{"fields": {"auto_redact_patterns": [...]}}`) previously had no effect: only the legacy `fields.patterns` key was merged, and the pattern compiler ignored that key when `auto_redact_patterns` was present. The merge now extends `auto_redact_patterns`, `flag_patterns`, and the legacy `patterns` list. File-path custom-pattern consumers that relied on the silent no-op will start seeing their extensions apply.
+
 ## [0.6.1] - 2026-04-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`include_patterns` in domain pattern files** — Domain JSON files (e.g. `network_device.json`) can declare an `include_patterns` list to filter the merged `pii.patterns` set down to only the entries that domain needs. Supports exact pattern names (`"mac_address"`) and glob wildcards (`"credit_card_*"`). Prevents false positives such as the credit-card regex triggering on cable-modem duration floats. The built-in `network_device.json` ships with an `include_patterns` list. See `docs/specs/PATTERN_SPEC.md` for the schema and merge order.
 - **`sanitize_post_data(..., custom_patterns=...)` now extends field detection** — The `custom_patterns` kwarg (file path or dict matching the `load_sensitive_patterns` schema, e.g. `{"fields": {"auto_redact_patterns": ["pws"]}}`) additively extends the auto-redact and flag regex sets for the call across form params, `application/x-www-form-urlencoded` bodies, JSON bodies, and XML bodies. Previously the kwarg was accepted but field-name detection always used the module-global patterns. The override is plumbed through a `ContextVar`-scoped resolver, so it is thread- and asyncio-safe by construction and does not mutate module state. Compiled regex pairs are cached per canonical key so repeated calls with the same extension skip the compile. Enables downstream consumers (e.g., Cable Modem Monitor) to redact device-specific credential field names without modifying the universal `sensitive.json`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-24
+
 ### Added
 
 - **`sanitize_post_data(..., custom_patterns=...)` now extends field detection** — The `custom_patterns` kwarg (file path or dict matching the `load_sensitive_patterns` schema, e.g. `{"fields": {"auto_redact_patterns": ["pws"]}}`) additively extends the auto-redact and flag regex sets for the call across form params, `application/x-www-form-urlencoded` bodies, JSON bodies, and XML bodies. Previously the kwarg was accepted but field-name detection always used the module-global patterns. The override is plumbed through a `ContextVar`-scoped resolver, so it is thread- and asyncio-safe by construction and does not mutate module state. Compiled regex pairs are cached per canonical key so repeated calls with the same extension skip the compile. Enables downstream consumers (e.g., Cable Modem Monitor) to redact device-specific credential field names without modifying the universal `sensitive.json`.
@@ -485,4 +487,5 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.5.1]: https://github.com/solentlabs/har-capture/compare/v0.5.0...v0.5.1
 [0.6.0]: https://github.com/solentlabs/har-capture/compare/v0.5.1...v0.6.0
 [0.6.1]: https://github.com/solentlabs/har-capture/compare/v0.6.0...v0.6.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.6.1...HEAD
+[0.7.0]: https://github.com/solentlabs/har-capture/compare/v0.6.1...v0.7.0
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.7.0...HEAD

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ sanitize_har_file("capture.har")  # → capture.sanitized.har
 # Custom patterns (e.g., modem serials, customer IDs)
 custom = {"patterns": {"modem_sn": {"regex": r"SN[0-9]{10}", "replacement_prefix": "MODEM"}}}
 sanitize_har_file("capture.har", custom_patterns=custom)
+
+# Redact device-specific credential FIELD NAMES (not just value patterns).
+# See docs/CUSTOM_PATTERNS.md#extending-sensitive-field-detection.
+device_fields = {"fields": {"auto_redact_patterns": ["pws"]}}
+sanitize_har_file("capture.har", custom_patterns=device_fields)
 ```
 
 ______________________________________________________________________

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,7 +177,9 @@ This means a consumer like cable_modem_monitor ships its own pattern file and ge
 
 **Confidence boundary:** Domain `pii.patterns` entries run as Pass 0 auto-redaction — they must have 100% confidence (zero false positives). Domain `heuristics.detectors` entries flag values for interactive review and can tolerate lower confidence. When a domain-specific pattern cannot guarantee zero false positives, it belongs in `heuristics.detectors`, not `pii.patterns`.
 
-See [Pattern Spec](specs/PATTERN_SPEC.md) for file schemas, merge semantics, and the loader/cache architecture.
+**Two extension points, one policy.** The file-based `--patterns` flow above is the *static* extension point: merge happens once at load time and the merged set is cached. A *dynamic* extension point also exists for library callers that only know their pattern list at runtime — `sanitize_post_data(..., custom_patterns=...)` and `sanitize_html(..., custom_patterns=...)` accept the same dict schema and apply it as a per-call override via a `ContextVar`. The ContextVar is read by `is_sensitive_field` / `is_flaggable_field` at every detection site, so field-name extensions reach form params, JSON/XML bodies, and inline-script scanners without any signature plumbing. The override is thread- and asyncio-scoped, additive to built-ins, and never mutates module state — independent callers with different extensions do not observe each other's patterns. This is the mechanism cable_modem_monitor uses to pass per-device credential field names (e.g. `pws`) without editing the universal `sensitive.json`.
+
+See [Pattern Spec](specs/PATTERN_SPEC.md) for file schemas, merge semantics, and the loader/cache architecture; [Sanitization Spec](specs/SANITIZATION_SPEC.md) for the ContextVar scope; and [Custom Patterns Guide](CUSTOM_PATTERNS.md#extending-sensitive-field-detection) for the user-facing recipe.
 
 ## Functional Specs
 

--- a/docs/CUSTOM_PATTERNS.md
+++ b/docs/CUSTOM_PATTERNS.md
@@ -98,6 +98,107 @@ patterns_dict = {
 sanitize_har_file("capture.har", custom_patterns=patterns_dict)
 ```
 
+## Extending Sensitive Field Detection
+
+The examples above extend `pii.patterns` — value-based regexes that match anywhere in content (e.g. a customer-ID string format). Field-level redaction is a separate pass: when sanitizing form bodies, JSON bodies, XML elements, `postData.params`, or inline `localStorage.setItem` calls, the engine checks the **field name** against two regex sets loaded from `sensitive.json`:
+
+- **`fields.auto_redact_patterns`** — field names that trigger automatic redaction of the associated value (100% confidence, e.g. `password`, `secret`, `token`).
+- **`fields.flag_patterns`** — field names that flag the value for interactive review (e.g. `username`, `account_id`).
+
+To add a field name that the built-ins don't recognize — for instance, a device-specific credential field like `pws`, `loginPassword`, or a product-specific token name — use the same `custom_patterns` kwarg with the `fields` schema. Extensions are additive (built-ins continue to apply) and scoped to the single call via a `ContextVar`, so module state is never mutated and concurrent callers don't observe each other's patterns.
+
+### Schema
+
+```json
+{
+  "fields": {
+    "auto_redact_patterns": ["pws", "custom_token"],
+    "flag_patterns": ["deploy_env"]
+  }
+}
+```
+
+Each entry is a regex (same syntax as the built-in `sensitive.json`). Matching is case-insensitive; use `\b` boundaries to avoid accidental substring hits.
+
+### Python API — per-call extension
+
+```python
+from har_capture.sanitization import sanitize_post_data
+
+# Device-specific credential field from a product catalog at runtime.
+custom = {"fields": {"auto_redact_patterns": ["pws"]}}
+
+post_data = {
+    "mimeType": "application/x-www-form-urlencoded",
+    "text": "user=admin&pws=hunter2",
+}
+
+result = sanitize_post_data(post_data, custom_patterns=custom)
+# result["text"] == "user=admin&pws=[REDACTED]"
+```
+
+The same extension applies to `sanitize_html` for inline-script field matching:
+
+```python
+from har_capture.sanitization import sanitize_html
+
+html = 'localStorage.setItem("pws", "hunter2")'
+clean = sanitize_html(html, custom_patterns=custom)
+# "hunter2" is redacted; key name "pws" is preserved.
+```
+
+And to the top-level entry points that delegate to these:
+
+```python
+from har_capture.sanitization import sanitize_har_file
+
+sanitize_har_file(
+    "capture.har",
+    custom_patterns={"fields": {"auto_redact_patterns": ["pws"]}},
+)
+```
+
+### File form (same schema)
+
+Anywhere a dict works, a file path containing the same JSON works too:
+
+```json
+{
+  "_comment": "custom_fields.json",
+  "fields": {
+    "auto_redact_patterns": ["pws", "custom_token"]
+  }
+}
+```
+
+```bash
+har-capture sanitize capture.har --patterns custom_fields.json
+```
+
+### Scope and isolation
+
+- The override applies only to the call that passes `custom_patterns`.
+- Module-level patterns (`sensitive.json`) are never mutated.
+- The override uses a `ContextVar`, so concurrent threads / asyncio tasks observe their own patterns with no cross-talk.
+- Compiled regexes are cached per canonical key, so repeated calls with the same extension skip the recompile.
+
+### Combining with `pii.patterns`
+
+A single dict (or file) can extend both `pii.patterns` and `fields` at once:
+
+```python
+custom = {
+    "patterns": {
+        "modem_serial": {"regex": r"SN[0-9]{10}", "replacement_prefix": "MODEM_SN"},
+    },
+    "fields": {
+        "auto_redact_patterns": ["pws"],
+        "flag_patterns": ["deploy_env"],
+    },
+}
+sanitize_har_file("capture.har", custom_patterns=custom)
+```
+
 ## Pattern Examples
 
 ### Serial Numbers

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -959,3 +959,62 @@ Field Engineer                     CMM Pipeline
      │                                  │  read _solentlabs (pre_capture_cookies)
      │                                  │  store in database
 ```
+
+______________________________________________________________________
+
+### UC-42: Redact Device-Specific Credential Fields at Runtime
+
+**Actor**: A downstream library (e.g. CMM) that captures auth traffic at runtime and knows, from its device catalog, which field names carry credentials for a particular model.
+
+**Goal**: Feed runtime-known credential field names (from a product catalog, YAML config, or database lookup) into sanitization without modifying the universal `sensitive.json` or maintaining a consumer-side pre-redaction helper.
+
+**Preconditions**:
+
+- Consumer has a `postData`-shaped dict from a live HTTP capture (e.g. via a Playwright session adapter).
+- Consumer has the field-name list for the current device (e.g. a `credential_fields` entry of `["pws"]` loaded from `modem.yaml`).
+- Consumer wants one canonical sanitization policy (har-capture's) rather than its own pre-pass.
+
+**Flow**:
+
+1. Consumer resolves the device's credential field names from its catalog at runtime.
+1. Consumer builds a `custom_patterns` dict of shape `{"fields": {"auto_redact_patterns": [...]}}`.
+1. Consumer passes that dict to `sanitize_post_data(..., custom_patterns=...)`.
+1. har-capture merges the extensions with built-ins for this call only (via a `ContextVar` scope) and returns sanitized `postData`.
+1. Subsequent calls for a different device with a different field list use their own dict; no state bleeds between calls.
+
+**Code Example**:
+
+```python
+from har_capture.sanitization import sanitize_post_data
+
+def redact_capture_for_device(post_data: dict, device_spec: dict) -> dict:
+    """Sanitize a captured postData using per-device credential field names."""
+    custom = {
+        "fields": {
+            "auto_redact_patterns": device_spec.get("credential_field_names", []),
+        },
+    }
+    return sanitize_post_data(post_data, custom_patterns=custom)
+
+# Example: a Hitron CODA56 catalog entry lists "pws" as its credential field
+hitron_spec = {"credential_field_names": ["pws"]}
+captured = {
+    "mimeType": "application/x-www-form-urlencoded",
+    "text": "user=admin&pws=hunter2",
+}
+redact_capture_for_device(captured, hitron_spec)
+# → {"mimeType": "...", "text": "user=admin&pws=[REDACTED]"}
+
+# Same process with a Motorola MB7621 (different field name) using the SAME
+# process — no global state change, no interference.
+motorola_spec = {"credential_field_names": ["loginPassword"]}
+# ... etc.
+```
+
+**Variations**:
+
+- Consumer wants to also flag (not auto-redact) a non-credential field for review → pass `{"fields": {"flag_patterns": ["deploy_env"]}}` alongside.
+- Consumer already has a JSON file on disk → pass the path as a string; the loader reads it and the regex cache keys off the resolved absolute path.
+- Concurrent captures for different devices (threaded or asyncio) → each call sees its own pattern set because the override lives in a `ContextVar`.
+
+**Why not edit `sensitive.json`?** That file captures universal PII rules. Device-specific credential names (`pws`, `loginPassword`, vendor-proprietary tokens) don't belong there because they'd apply to every capture across every consumer. The per-call hook keeps the universal set small and lets each consumer carry its own catalog.

--- a/docs/specs/PATTERN_SPEC.md
+++ b/docs/specs/PATTERN_SPEC.md
@@ -234,6 +234,8 @@ A domain file can contain any combination of these sections:
     "safe_values": ["domain-specific-safe-value"]
   },
 
+  "include_patterns": ["mac_address", "serial_number", "private_ip", "public_ip", "ipv6", "email"],
+
   "pii": {
     "patterns": {
       "pattern_name": {
@@ -303,6 +305,34 @@ The detection loop in `heuristics.py`:
 Case-insensitive exact-match strings safe in pipe-delimited data. Domain-specific technical vocabulary.
 
 Examples for `network-device`: `qam256`, `atdma`, `bpi+`, `honor mdd`, `dhcpclient`
+
+### Section: `include_patterns`
+
+Top-level list of PII pattern names that are relevant to this domain. When present, only matching patterns survive the merge — all others are removed. Supports exact names and glob wildcards. Applied by `load_pii_patterns()` after custom patterns are merged into the core set.
+
+```json
+{
+  "include_patterns": ["mac_address", "serial_number", "private_ip", "public_ip", "ipv6", "email", "docsis_account"],
+
+  "patterns": {
+    "docsis_account": {
+      "regex": "\\bCM-ACCT-\\d{8,}\\b",
+      "replacement_prefix": "DOCSIS",
+      "description": "DOCSIS cable modem account identifier"
+    }
+  }
+}
+```
+
+| Field              | Type       | Description                                          |
+| ------------------ | ---------- | ---------------------------------------------------- |
+| `include_patterns` | string\[\] | Pattern names or globs to keep in the merged PII set |
+
+The domain knows its data. A cable modem page contains MAC addresses, IPs, and serial numbers — not credit cards or SSNs. The domain declares which PII categories are relevant, including both core patterns and domain-added patterns from `pii.patterns`. The inclusion filter runs after the merge, so domain-specific patterns are first-class citizens alongside core patterns.
+
+When `include_patterns` is absent, all core patterns are applied (backward compatible). When multiple `--patterns` files are specified, `include_patterns` lists are accumulated across all files before being applied.
+
+As domain-specific patterns prove valuable across multiple consumers, they can be graduated to core (`pii.json`) — at which point existing domain files that already name them in `include_patterns` continue to work unchanged.
 
 ### Section: `pii.patterns`
 

--- a/docs/specs/PATTERN_SPEC.md
+++ b/docs/specs/PATTERN_SPEC.md
@@ -379,12 +379,25 @@ Merge semantics (applied at each layer):
 # Lists are extended (custom appended to builtin)
 builtin["headers"]["full_redact"].extend(custom["headers"]["full_redact"])
 
+# Field-name regex lists extend additively. Both the current-schema keys
+# (auto_redact_patterns, flag_patterns) and the legacy `patterns` key are
+# honored and extend whatever list already exists on builtin.
+for key in ("auto_redact_patterns", "flag_patterns", "patterns"):
+    builtin["fields"].setdefault(key, []).extend(custom["fields"].get(key, []))
+
 # Dicts are updated (custom overrides builtin keys)
 builtin["patterns"].update(custom["patterns"])
 
 # Missing sections are handled gracefully
 builtin.setdefault("heuristics", {})
 ```
+
+> **Note:** Prior to 0.7.0, `load_sensitive_patterns` merged only the legacy
+> `fields.patterns` key and silently dropped `fields.auto_redact_patterns` /
+> `fields.flag_patterns` from custom inputs — even though both keys appear in
+> the built-in `sensitive.json` schema. The merge now honors all three. File-
+> or dict-based consumers that previously worked around this by editing
+> `sensitive.json` directly can switch to the `custom_patterns` kwarg.
 
 ## Loader Architecture
 

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -124,6 +124,8 @@ def is_flaggable_field(name: str) -> bool:
 
 Patterns loaded from `sensitive.json` `fields.auto_redact_patterns` and `fields.flag_patterns`. Fallback patterns (hardcoded): `["password", "secret", "token", "\\bkey\\b", "\\bauth\\b"]`.
 
+Callers can extend these per-call via `sanitize_post_data(..., custom_patterns=...)` or `sanitize_html(..., custom_patterns=...)`. The extension is additive (never replacing built-ins) and is applied via a `ContextVar`-scoped override that both public entry points enter at the top of the call. Inner helpers (`_sanitize_form_urlencoded`, `_sanitize_json_recursive`, `_sanitize_xml_fields`, the inline-script `setItem` scanner, and any other site that calls `is_sensitive_field` / `is_flaggable_field`) pick up the active set automatically, with no signature plumbing. Because `ContextVar` is thread- and asyncio-scoped, concurrent callers observe only their own patterns.
+
 ### POST Data Sanitization
 
 ```python
@@ -142,6 +144,8 @@ def sanitize_post_data(
 1. **JSON body** (`_sanitize_json_recursive`): Recursive traversal with depth limit (50). Object keys checked against field patterns; values redacted if key is sensitive.
 1. **XML body** (`sanitize_html`): Detected via `text/xml` or `application/xml` content type. Delegated to the HTML content engine, which runs the full scanner pipeline. XML POST bodies from device APIs (e.g., modem XML getter/setter endpoints) are sanitized identically to XML response content.
 1. **Raw text**: Falls through to string pattern matching.
+
+**Per-call `custom_patterns`** extends the auto-redact and flag regex sets across all four branches (params, form, JSON, XML) via a `ContextVar`-scoped override entered at the top of `sanitize_post_data`. The dict shape mirrors `sensitive.json`, e.g. `{"fields": {"auto_redact_patterns": ["pws"]}}`. Module-global patterns are never mutated; the override is scoped per thread / asyncio task. Compiled regex pairs are cached per canonical key so repeated calls with the same extension avoid recompilation. `sanitize_html` enters the same scope, so the XML branch's delegation to the HTML engine honors the override end-to-end.
 
 ### URL Sanitization
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,6 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["src/har_capture"]
 branch = true
-parallel = true
 
 [tool.coverage.paths]
 source = ["src/har_capture"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.6.1"
+version = "0.7.0"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/patterns/domains/network_device.json
+++ b/src/har_capture/patterns/domains/network_device.json
@@ -1,6 +1,22 @@
 {
   "_description": "Safe values for network devices (routers, modems, access points, switches)",
 
+  "include_patterns": [
+    "mac_address",
+    "serial_number",
+    "account_id",
+    "private_ip",
+    "public_ip",
+    "ipv6",
+    "email",
+    "password_field",
+    "password_input",
+    "session_token",
+    "csrf_token",
+    "config_path",
+    "motorola_password"
+  ],
+
   "heuristics": {
     "detectors": [
       {

--- a/src/har_capture/patterns/loader.py
+++ b/src/har_capture/patterns/loader.py
@@ -11,6 +11,7 @@ import logging
 import re
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -133,6 +134,24 @@ def _load_custom_patterns(custom: Path | str | dict[str, Any]) -> dict[str, Any]
     return load_json_file(custom)
 
 
+def _apply_pattern_inclusions(patterns: dict[str, Any], inclusions: list[str]) -> None:
+    """Keep only patterns whose names match an entry in the inclusion list.
+
+    Supports exact names (``"mac_address"``) and glob wildcards
+    (``"credit_card_*"``).  Modifies *patterns* in place.
+
+    Args:
+        patterns: The ``patterns`` dict (pattern_name → definition).
+        inclusions: List of pattern names or glob expressions to keep.
+    """
+    exact = {e for e in inclusions if "*" not in e}
+    globs = [e for e in inclusions if "*" in e]
+
+    to_remove = [name for name in patterns if name not in exact and not any(fnmatch(name, g) for g in globs)]
+    for name in to_remove:
+        del patterns[name]
+
+
 def load_pii_patterns(custom_path: Path | str | dict[str, Any] | None = None) -> dict[str, Any]:
     """Load PII detection patterns.
 
@@ -169,6 +188,9 @@ def load_pii_patterns(custom_path: Path | str | dict[str, Any] | None = None) ->
             builtin["patterns"].update(custom["patterns"])
         if "preserved_gateway_ips" in custom and isinstance(custom["preserved_gateway_ips"], list):
             builtin["preserved_gateway_ips"].extend(custom["preserved_gateway_ips"])
+        # Apply inclusions declared by the domain/custom file
+        if "include_patterns" in custom and isinstance(custom["include_patterns"], list):
+            _apply_pattern_inclusions(builtin["patterns"], custom["include_patterns"])
 
     if cache_key:
         _cache_set(cache_key, builtin)
@@ -535,6 +557,10 @@ def merge_pattern_files(paths: list[Path]) -> dict[str, Any]:
                     merged[section][key].update(val)
                 else:
                     merged[section][key] = val
+        # Accumulate include_patterns across files (list extend)
+        if "include_patterns" in extra and isinstance(extra["include_patterns"], list):
+            merged.setdefault("include_patterns", [])
+            merged["include_patterns"].extend(extra["include_patterns"])
     return merged
 
 

--- a/src/har_capture/patterns/loader.py
+++ b/src/har_capture/patterns/loader.py
@@ -231,8 +231,14 @@ def load_sensitive_patterns(custom_path: Path | str | dict[str, Any] | None = No
                 builtin["headers"]["full_redact"].extend(custom["headers"]["full_redact"])
             if "cookie_redact" in custom["headers"]:
                 builtin["headers"]["cookie_redact"].extend(custom["headers"]["cookie_redact"])
-        if "fields" in custom and "patterns" in custom["fields"]:
-            builtin["fields"]["patterns"].extend(custom["fields"]["patterns"])
+        if "fields" in custom and isinstance(custom["fields"], dict):
+            custom_fields = custom["fields"]
+            # Extend each known list key. "patterns" is the legacy key; the current
+            # schema uses "auto_redact_patterns" and "flag_patterns".
+            for key in ("auto_redact_patterns", "flag_patterns", "patterns"):
+                values = custom_fields.get(key)
+                if isinstance(values, list):
+                    builtin["fields"].setdefault(key, []).extend(values)
         if "tagValueList" in custom and "safe_values" in custom["tagValueList"]:
             builtin["tagValueList"]["safe_values"].extend(custom["tagValueList"]["safe_values"])
         if "heuristics" in custom:

--- a/src/har_capture/sanitization/har.py
+++ b/src/har_capture/sanitization/har.py
@@ -9,11 +9,16 @@ Reuses PII patterns from html.py for consistency.
 
 from __future__ import annotations
 
+import contextvars
 import copy
 import json
 import logging
 import re
 import urllib.parse
+from collections import OrderedDict
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from har_capture.patterns import (
@@ -27,7 +32,7 @@ from har_capture.sanitization.html import is_valid_ip_address, sanitize_html
 from har_capture.sanitization.report import ConfidenceLevel
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Iterator
 
     from har_capture.sanitization.report import HeuristicMode, SanitizationReport
 else:
@@ -145,15 +150,16 @@ def _load_sensitive_headers() -> tuple[set[str], set[str]]:
     return full_redact, cookie_redact
 
 
-def _load_sensitive_field_patterns() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
-    """Load sensitive field patterns from patterns file.
+def _compile_sensitive_field_patterns(
+    sensitive_data: dict[str, Any],
+) -> tuple[re.Pattern[str], re.Pattern[str] | None]:
+    """Compile (auto_redact, flag) regexes from a loaded sensitive-patterns dict.
 
     Returns:
         Tuple of (auto_redact_pattern, flag_pattern) compiled regexes.
         flag_pattern is None if no flag patterns are defined.
     """
-    sensitive = load_sensitive_patterns()
-    fields = sensitive.get("fields", {})
+    fields = sensitive_data.get("fields", {})
     auto_patterns = fields.get("auto_redact_patterns", [])
     flag_patterns = fields.get("flag_patterns", [])
 
@@ -170,9 +176,114 @@ def _load_sensitive_field_patterns() -> tuple[re.Pattern[str], re.Pattern[str] |
     return auto_re, flag_re
 
 
+def _load_sensitive_field_patterns() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
+    """Load and compile sensitive field patterns from the built-in patterns file."""
+    return _compile_sensitive_field_patterns(load_sensitive_patterns())
+
+
 # Load patterns at module level for efficiency
 _FULL_REDACT_HEADERS, _COOKIE_REDACT_HEADERS = _load_sensitive_headers()
 _SENSITIVE_FIELD_RE, _SENSITIVE_FLAG_FIELD_RE = _load_sensitive_field_patterns()
+
+
+@dataclass(frozen=True)
+class _FieldPatternSet:
+    """Resolved auto-redact and flag regexes used for one sanitization call.
+
+    ``flag_re`` is None when no flag patterns are configured — that is a
+    legitimate state, distinct from "use the default pattern set", which is
+    expressed by passing ``None`` in place of an entire ``_FieldPatternSet``.
+    """
+
+    field_re: re.Pattern[str]
+    flag_re: re.Pattern[str] | None
+
+    def matches_sensitive(self, field_name: str) -> bool:
+        return bool(self.field_re.search(field_name))
+
+    def matches_flaggable(self, field_name: str) -> bool:
+        if self.flag_re is None:
+            return False
+        return bool(self.flag_re.search(field_name))
+
+
+_DEFAULT_FIELD_PATTERNS = _FieldPatternSet(_SENSITIVE_FIELD_RE, _SENSITIVE_FLAG_FIELD_RE)
+
+# Per-call field-pattern override. ContextVar because (a) overrides must be
+# scoped to a single sanitize call without leaking to concurrent work, and
+# (b) ContextVar is the stdlib-native primitive for thread- and asyncio-safe
+# dynamic scope — no manual locking required.
+_FIELD_PATTERNS_CTX: contextvars.ContextVar[_FieldPatternSet] = contextvars.ContextVar(
+    "har_capture_field_patterns", default=_DEFAULT_FIELD_PATTERNS
+)
+
+
+@contextmanager
+def _field_patterns_scope(custom_patterns: str | dict[str, Any] | None) -> Iterator[None]:
+    """Apply ``custom_patterns`` as the active field-pattern set for this scope.
+
+    Restores the previous set on exit even if an exception escapes. Designed
+    to be called at public entry points (``sanitize_post_data``, ``sanitize_html``);
+    inner helpers simply call ``is_sensitive_field`` / ``is_flaggable_field`` and
+    pick up the active set automatically.
+    """
+    token = _FIELD_PATTERNS_CTX.set(_resolve_field_patterns(custom_patterns))
+    try:
+        yield
+    finally:
+        _FIELD_PATTERNS_CTX.reset(token)
+
+
+# Per-call regex cache for custom_patterns extensions. Keyed by a canonical
+# representation of the custom_patterns argument. Module globals above are
+# never mutated — each entry here is an independent compiled pair.
+_CUSTOM_FIELD_RE_CACHE_MAX = 32
+_CUSTOM_FIELD_RE_CACHE: OrderedDict[str, _FieldPatternSet] = OrderedDict()
+
+
+def _custom_patterns_cache_key(custom_patterns: str | dict[str, Any]) -> str | None:
+    """Derive a stable cache key for a custom_patterns argument.
+
+    Returns None if the argument is not hashable in a stable way (in which
+    case the caller should skip the cache and compile fresh).
+    """
+    if isinstance(custom_patterns, dict):
+        try:
+            return "dict:" + json.dumps(custom_patterns, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            return None
+    return "path:" + str(Path(custom_patterns).resolve())
+
+
+def _resolve_field_patterns(
+    custom_patterns: str | dict[str, Any] | None,
+) -> _FieldPatternSet:
+    """Resolve the auto-redact + flag regex pair for this call.
+
+    ``custom_patterns=None`` returns the shared default set (today's behavior,
+    zero-cost). Otherwise the custom patterns are merged with built-ins via
+    the loader and the compiled result is cached per canonical key so repeat
+    calls don't recompile.
+    """
+    if custom_patterns is None:
+        return _DEFAULT_FIELD_PATTERNS
+
+    key = _custom_patterns_cache_key(custom_patterns)
+    if key is not None:
+        cached = _CUSTOM_FIELD_RE_CACHE.get(key)
+        if cached is not None:
+            _CUSTOM_FIELD_RE_CACHE.move_to_end(key)
+            return cached
+
+    field_re, flag_re = _compile_sensitive_field_patterns(load_sensitive_patterns(custom_patterns))
+    resolved = _FieldPatternSet(field_re, flag_re)
+
+    if key is not None:
+        _CUSTOM_FIELD_RE_CACHE[key] = resolved
+        while len(_CUSTOM_FIELD_RE_CACHE) > _CUSTOM_FIELD_RE_CACHE_MAX:
+            _CUSTOM_FIELD_RE_CACHE.popitem(last=False)
+    return resolved
+
 
 # Redaction placeholder - single source of truth
 REDACTED = "[REDACTED]"
@@ -205,6 +316,10 @@ def _redact_value(
 def is_sensitive_field(field_name: str) -> bool:
     """Check if a form field name matches auto-redact patterns (100% confidence).
 
+    Reads the active field-pattern set from the ``_field_patterns_scope``
+    context manager when one is entered; otherwise uses the module-wide
+    defaults from ``sensitive.json``.
+
     Args:
         field_name: Name of the form field
 
@@ -219,7 +334,7 @@ def is_sensitive_field(field_name: str) -> bool:
         >>> is_sensitive_field("channel_id")
         False
     """
-    return bool(_SENSITIVE_FIELD_RE.search(field_name))
+    return _FIELD_PATTERNS_CTX.get().matches_sensitive(field_name)
 
 
 def is_flaggable_field(field_name: str) -> bool:
@@ -227,6 +342,7 @@ def is_flaggable_field(field_name: str) -> bool:
 
     These are fields that may contain sensitive data but are not certain
     enough for auto-redaction. They are flagged for interactive user review.
+    Honors an active ``_field_patterns_scope`` override.
 
     Args:
         field_name: Name of the form field
@@ -242,9 +358,7 @@ def is_flaggable_field(field_name: str) -> bool:
         >>> is_flaggable_field("channel_id")
         False
     """
-    if _SENSITIVE_FLAG_FIELD_RE is None:
-        return False
-    return bool(_SENSITIVE_FLAG_FIELD_RE.search(field_name))
+    return _FIELD_PATTERNS_CTX.get().matches_flaggable(field_name)
 
 
 def sanitize_header_value(
@@ -372,7 +486,13 @@ def sanitize_post_data(
         post_data: HAR postData object
         hasher: Optional hasher for correlation-preserving redaction
         collector: Optional collector to record redactions
-        custom_patterns: Optional custom patterns (file path or dict)
+        custom_patterns: Optional additive custom patterns (file path or dict
+            matching the ``load_sensitive_patterns`` schema, e.g.
+            ``{"fields": {"auto_redact_patterns": ["pws"]}}``). Extends — not
+            replaces — the built-in auto-redact and flag patterns for THIS
+            CALL ONLY via a ``ContextVar``-scoped override. Module-global
+            state is never mutated, and independent threads / asyncio tasks
+            receive their own copy of the context.
         heuristics: Heuristic mode for content engine
 
     Returns:
@@ -383,38 +503,39 @@ def sanitize_post_data(
 
     result = copy.deepcopy(post_data)
 
-    # Sanitize params array
-    if "params" in result and isinstance(result["params"], list):
-        for param in result["params"]:
-            if isinstance(param, dict) and "name" in param:
-                if is_sensitive_field(param["name"]):
-                    param["value"] = _redact_value(param.get("value", ""), hasher, "FIELD", collector)
-                elif is_flaggable_field(param["name"]) and collector and param.get("value"):
-                    collector.flag_value(
-                        param["value"],
-                        "field",
-                        ConfidenceLevel.MEDIUM,
-                        f"POST param '{param['name']}'",
-                        f"Flaggable field name '{param['name']}' in POST params",
-                    )
+    with _field_patterns_scope(custom_patterns):
+        # Sanitize params array
+        if "params" in result and isinstance(result["params"], list):
+            for param in result["params"]:
+                if isinstance(param, dict) and "name" in param:
+                    if is_sensitive_field(param["name"]):
+                        param["value"] = _redact_value(param.get("value", ""), hasher, "FIELD", collector)
+                    elif is_flaggable_field(param["name"]) and collector and param.get("value"):
+                        collector.flag_value(
+                            param["value"],
+                            "field",
+                            ConfidenceLevel.MEDIUM,
+                            f"POST param '{param['name']}'",
+                            f"Flaggable field name '{param['name']}' in POST params",
+                        )
 
-    # Sanitize raw text (form-urlencoded, JSON, or XML)
-    if result.get("text"):
-        text = result["text"]
-        mime_type = result.get("mimeType", "")
+        # Sanitize raw text (form-urlencoded, JSON, or XML)
+        if result.get("text"):
+            text = result["text"]
+            mime_type = result.get("mimeType", "")
 
-        if "application/x-www-form-urlencoded" in mime_type:
-            result["text"] = _sanitize_form_urlencoded(text, hasher, collector)
-        elif "application/json" in mime_type:
-            result["text"] = _sanitize_json_text(text, hasher, collector)
-        elif "text/xml" in mime_type or "application/xml" in mime_type:
-            text = _sanitize_xml_fields(text, hasher, collector)
-            result["text"] = sanitize_html(
-                text,
-                collector=collector,
-                custom_patterns=custom_patterns,
-                heuristics=heuristics,
-            )
+            if "application/x-www-form-urlencoded" in mime_type:
+                result["text"] = _sanitize_form_urlencoded(text, hasher, collector)
+            elif "application/json" in mime_type:
+                result["text"] = _sanitize_json_text(text, hasher, collector)
+            elif "text/xml" in mime_type or "application/xml" in mime_type:
+                text = _sanitize_xml_fields(text, hasher, collector)
+                result["text"] = sanitize_html(
+                    text,
+                    collector=collector,
+                    custom_patterns=custom_patterns,
+                    heuristics=heuristics,
+                )
 
     return result
 
@@ -978,7 +1099,15 @@ def sanitize_entry(
     Args:
         entry: HAR entry object
         salt: Salt for hashed redaction (ignored if collector provided)
-        custom_patterns: Optional custom patterns (file path or dict)
+        custom_patterns: Optional additive custom patterns (file path or dict
+            matching the ``load_sensitive_patterns`` schema). Extends the
+            built-in ``pii.patterns``, allowlist, and sensitive-field sets
+            (``fields.auto_redact_patterns`` / ``fields.flag_patterns``) for
+            this call only. Propagates end-to-end: the scope is entered by
+            ``sanitize_post_data`` and ``sanitize_html`` downstream, so
+            field-name extensions reach form params, JSON/XML bodies, and
+            inline-script scanners. Module-global state is never mutated.
+            See ``sanitize_post_data`` for the full contract.
         collector: Optional collector for tracking redactions
         heuristics: Heuristic mode for pipe-delimited value detection
         _skip_copy: If True, skip deep copy (caller already copied). Internal use only.
@@ -1059,7 +1188,15 @@ def sanitize_har(
             - "auto" (default): Random salt, correlates within this call
             - None: Static placeholders (legacy behavior)
             - Any string: Consistent hashing across calls with same salt
-        custom_patterns: Optional custom patterns (file path or dict)
+        custom_patterns: Optional additive custom patterns (file path or dict
+            matching the ``load_sensitive_patterns`` schema). Extends the
+            built-in ``pii.patterns``, allowlist, and sensitive-field sets
+            (``fields.auto_redact_patterns`` / ``fields.flag_patterns``) for
+            this call only. Applies across every entry: request/response
+            headers, POST params and bodies (form / JSON / XML), and any
+            inline-script field matching inside HTML content. Module-global
+            state is never mutated. See ``sanitize_post_data`` for the full
+            contract.
         heuristics: Heuristic mode for pipe-delimited value detection
 
     Returns:
@@ -1167,7 +1304,15 @@ def sanitize_har_file(
         input_path: Path to input HAR file
         output_path: Path to output file (default: input_path with .sanitized.har suffix)
         salt: Salt for hashed redaction
-        custom_patterns: Optional custom patterns (file path or dict)
+        custom_patterns: Optional additive custom patterns (file path or dict
+            matching the ``load_sensitive_patterns`` schema). Extends the
+            built-in ``pii.patterns``, allowlist, and sensitive-field sets
+            (``fields.auto_redact_patterns`` / ``fields.flag_patterns``) for
+            this call only. Applied consistently across every entry in the
+            HAR — request/response headers, POST bodies, and inline-script
+            scanners inside HTML content. Module-global state is never
+            mutated. See ``sanitize_post_data`` for the full contract and
+            ``docs/CUSTOM_PATTERNS.md`` for worked examples.
         max_size: Maximum file size in bytes (default: 100MB). Set to None to disable.
         validate: If True, validate HAR structure before processing (default: True)
         heuristics: Heuristic mode for pipe-delimited value detection

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -234,10 +234,22 @@ def sanitize_html(
             - None: Static placeholders (legacy behavior)
             - Any string: Consistent hashing across calls with same salt
             (ignored if collector is provided)
-        custom_patterns: Custom PII patterns to apply. Options:
+        custom_patterns: Custom patterns to apply. Extends the built-in
+            ``pii.patterns``, ``allowlist``, and sensitive-field sets
+            (``fields.auto_redact_patterns`` / ``fields.flag_patterns``) for
+            THIS CALL ONLY. Options:
+
             - String: Path to JSON patterns file
             - Dict: Pattern definitions directly (e.g., from modem.yaml)
             - None: Use built-in patterns only
+
+            Field-name extensions reach the inline-script scanner
+            (``localStorage.setItem`` / ``sessionStorage.setItem``) via a
+            ``ContextVar``-scoped override, so e.g. ``{"fields":
+            {"auto_redact_patterns": ["pws"]}}`` causes values associated
+            with ``"pws"`` keys in inline scripts to be redacted. Module-
+            global patterns are never mutated; concurrent threads / asyncio
+            tasks observe their own patterns.
         collector: Optional collector for tracking redactions
         heuristics: How to handle unlabeled pipe-delimited values:
             - DISABLED (default): Skip heuristics, only redact known patterns
@@ -263,6 +275,36 @@ def sanitize_html(
         hasher = Hasher.create(salt)
         collector = RedactionCollector(hasher=hasher)
 
+    # Enter the field-pattern scope so is_sensitive_field() calls inside the
+    # HTML scanner honor custom_patterns. Lazy import: har imports html at
+    # module level, so we'd cycle if this were top-level.
+    from har_capture.sanitization.har import (
+        _FIELD_PATTERNS_CTX,
+        _resolve_field_patterns,
+    )
+
+    _scope_token = _FIELD_PATTERNS_CTX.set(_resolve_field_patterns(custom_patterns))
+    try:
+        return _sanitize_html_impl(
+            html,
+            hasher=hasher,
+            collector=collector,
+            custom_patterns=custom_patterns,
+            heuristics=heuristics,
+        )
+    finally:
+        _FIELD_PATTERNS_CTX.reset(_scope_token)
+
+
+def _sanitize_html_impl(
+    html: str,
+    *,
+    hasher: Hasher,
+    collector: RedactionCollector,
+    custom_patterns: str | dict[str, Any] | None,
+    heuristics: HeuristicMode,
+) -> str:
+    """Inner body of :func:`sanitize_html` — runs inside the active field-pattern scope."""
     pii = load_pii_patterns(custom_patterns)
     sensitive = load_sensitive_patterns(custom_patterns)
 

--- a/tests/fixtures/test_har.json
+++ b/tests/fixtures/test_har.json
@@ -231,5 +231,166 @@
       "must_not_contain": ["topsecret"],
       "must_contain": []
     }
+  ],
+  "custom_patterns_cases": [
+    {
+      "id": "form_unknown_field_preserved_without_custom",
+      "post_data": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "pws=alsosecret"
+      },
+      "custom_patterns": null,
+      "must_contain": ["pws=alsosecret"],
+      "must_not_contain": []
+    },
+    {
+      "id": "form_unknown_field_redacted_with_custom",
+      "post_data": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "pws=alsosecret"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": ["pws=[REDACTED]"],
+      "must_not_contain": ["alsosecret"]
+    },
+    {
+      "id": "form_builtin_field_still_redacted_when_custom_present",
+      "post_data": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "user=admin&password=secret123&pws=alsosecret"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": ["password=[REDACTED]", "pws=[REDACTED]", "user=admin"],
+      "must_not_contain": ["secret123", "alsosecret"]
+    },
+    {
+      "id": "form_multiple_custom_patterns_all_applied",
+      "post_data": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "pws=one&twofactor=two&user=admin"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws", "twofactor"]}},
+      "must_contain": ["pws=[REDACTED]", "twofactor=[REDACTED]", "user=admin"],
+      "must_not_contain": ["=one", "=two"]
+    },
+    {
+      "id": "json_unknown_field_preserved_without_custom",
+      "post_data": {
+        "mimeType": "application/json",
+        "text": "{\"user\": \"admin\", \"pws\": \"alsosecret\"}"
+      },
+      "custom_patterns": null,
+      "must_contain": ["alsosecret"],
+      "must_not_contain": []
+    },
+    {
+      "id": "json_unknown_field_redacted_with_custom",
+      "post_data": {
+        "mimeType": "application/json",
+        "text": "{\"user\": \"admin\", \"pws\": \"alsosecret\"}"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": ["[REDACTED]"],
+      "must_not_contain": ["alsosecret"]
+    },
+    {
+      "id": "json_builtin_field_still_redacted_when_custom_present",
+      "post_data": {
+        "mimeType": "application/json",
+        "text": "{\"password\": \"secret123\", \"pws\": \"alsosecret\"}"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": [],
+      "must_not_contain": ["secret123", "alsosecret"]
+    },
+    {
+      "id": "json_nested_custom_pattern_reaches_deep_key",
+      "post_data": {
+        "mimeType": "application/json",
+        "text": "{\"outer\": {\"pws\": \"deepsecret\"}}"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": [],
+      "must_not_contain": ["deepsecret"]
+    },
+    {
+      "id": "xml_unknown_tag_preserved_without_custom",
+      "post_data": {
+        "mimeType": "text/xml",
+        "text": "<root><pws>alsosecret</pws></root>"
+      },
+      "custom_patterns": null,
+      "must_contain": ["alsosecret"],
+      "must_not_contain": []
+    },
+    {
+      "id": "xml_unknown_tag_redacted_with_custom",
+      "post_data": {
+        "mimeType": "text/xml",
+        "text": "<root><pws>alsosecret</pws></root>"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": [],
+      "must_not_contain": ["alsosecret"]
+    },
+    {
+      "id": "xml_builtin_tag_still_redacted_when_custom_present",
+      "post_data": {
+        "mimeType": "text/xml",
+        "text": "<root><password>secret123</password><pws>alsosecret</pws></root>"
+      },
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "must_contain": [],
+      "must_not_contain": ["secret123", "alsosecret"]
+    },
+    {
+      "id": "form_flag_patterns_extended_via_custom",
+      "post_data": {
+        "mimeType": "application/x-www-form-urlencoded",
+        "text": "deployenv=production"
+      },
+      "custom_patterns": {"fields": {"flag_patterns": ["deployenv"]}},
+      "must_contain": ["deployenv=production"],
+      "must_not_contain": []
+    }
+  ],
+  "custom_patterns_params_cases": [
+    {
+      "id": "params_unknown_field_preserved_without_custom",
+      "params": [
+        {"name": "pws", "value": "alsosecret"},
+        {"name": "user", "value": "admin"}
+      ],
+      "custom_patterns": null,
+      "expected_values": {"pws": "alsosecret", "user": "admin"}
+    },
+    {
+      "id": "params_unknown_field_redacted_with_custom",
+      "params": [
+        {"name": "pws", "value": "alsosecret"},
+        {"name": "user", "value": "admin"}
+      ],
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "expected_values": {"pws": "[REDACTED]", "user": "admin"}
+    },
+    {
+      "id": "params_builtin_field_still_redacted_when_custom_present",
+      "params": [
+        {"name": "loginPassword", "value": "secret123"},
+        {"name": "pws", "value": "alsosecret"}
+      ],
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws"]}},
+      "expected_values": {"loginPassword": "[REDACTED]", "pws": "[REDACTED]"}
+    },
+    {
+      "id": "params_multiple_custom_patterns_each_applied",
+      "params": [
+        {"name": "pws", "value": "one"},
+        {"name": "twofactor", "value": "two"},
+        {"name": "user", "value": "admin"}
+      ],
+      "custom_patterns": {"fields": {"auto_redact_patterns": ["pws", "twofactor"]}},
+      "expected_values": {"pws": "[REDACTED]", "twofactor": "[REDACTED]", "user": "admin"}
+    }
   ]
 }

--- a/tests/fixtures/test_loader.json
+++ b/tests/fixtures/test_loader.json
@@ -1,0 +1,66 @@
+{
+  "include_patterns_loader_cases": [
+    {
+      "domain_config": {"include_patterns": ["mac_address", "email"]},
+      "expected_present": ["mac_address", "email"],
+      "expected_absent": ["credit_card_visa", "ssn", "serial_number"],
+      "exact_set": true,
+      "id": "exact_names_keep_only_listed"
+    },
+    {
+      "domain_config": {"include_patterns": ["credit_card_*"]},
+      "expected_present": ["credit_card_visa", "credit_card_mastercard", "credit_card_amex"],
+      "expected_absent": ["mac_address", "email"],
+      "exact_set": false,
+      "id": "wildcard_keeps_category"
+    },
+    {
+      "domain_config": {"include_patterns": ["mac_address", "private_ip", "public_ip", "ipv6", "*_ip"]},
+      "expected_present": ["mac_address", "private_ip", "public_ip", "ipv6"],
+      "expected_absent": ["credit_card_visa", "ssn"],
+      "exact_set": false,
+      "id": "mixed_exact_and_wildcard"
+    },
+    {
+      "domain_config": {"tagValueList": {"safe_values": ["foo"]}},
+      "expected_present": ["credit_card_visa", "mac_address", "ssn"],
+      "expected_absent": [],
+      "exact_set": false,
+      "id": "no_include_patterns_preserves_all"
+    },
+    {
+      "domain_config": {
+        "include_patterns": ["mac_address", "docsis_account"],
+        "patterns": {
+          "docsis_account": {
+            "regex": "CM-ACCT-\\d{8,}",
+            "replacement_prefix": "DOCSIS"
+          }
+        }
+      },
+      "expected_present": ["mac_address", "docsis_account"],
+      "expected_absent": ["credit_card_visa", "ssn"],
+      "exact_set": true,
+      "id": "domain_custom_pattern_included"
+    }
+  ],
+
+  "include_patterns_pii_cases": [
+    {
+      "domain_config": {"include_patterns": ["mac_address"]},
+      "content": "MAC: DE:AD:BE:EF:CA:FE and card 4111111111111111",
+      "expected_detected": ["mac_address"],
+      "expected_not_detected": ["credit_card_visa"],
+      "id": "only_included_patterns_detected"
+    },
+    {
+      "domain_config": {
+        "include_patterns": ["mac_address", "serial_number", "private_ip", "public_ip", "ipv6", "email"]
+      },
+      "content": "poll_duration: 2.343620812986046",
+      "expected_detected": [],
+      "expected_not_detected": [],
+      "id": "cable_modem_false_positive_suppressed"
+    }
+  ]
+}

--- a/tests/test_patterns/test_loader.py
+++ b/tests/test_patterns/test_loader.py
@@ -19,6 +19,7 @@ from har_capture.patterns.loader import (
     load_json_file,
     load_pii_patterns,
     load_sensitive_patterns,
+    merge_pattern_files,
     resolve_patterns_arg,
 )
 
@@ -296,6 +297,100 @@ class TestCompileSafeValuePatterns:
         }
         patterns = compile_safe_value_patterns(data)
         assert len(patterns) == 1
+
+
+_LOADER_FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "test_loader.json"
+_LOADER_FIXTURE = json.loads(_LOADER_FIXTURE_PATH.read_text())
+
+INCLUDE_LOADER_CASES = [
+    (c["domain_config"], c["expected_present"], c["expected_absent"], c["exact_set"], c["id"])
+    for c in _LOADER_FIXTURE["include_patterns_loader_cases"]
+]
+
+INCLUDE_PII_CASES = [
+    (c["domain_config"], c["content"], c["expected_detected"], c["expected_not_detected"], c["id"])
+    for c in _LOADER_FIXTURE["include_patterns_pii_cases"]
+]
+
+
+class TestIncludePatterns:
+    """Tests for include_patterns in domain/custom pattern files."""
+
+    def setup_method(self) -> None:
+        """Clear cache before each test."""
+        clear_pattern_cache()
+
+    def teardown_method(self) -> None:
+        """Clear cache after each test."""
+        clear_pattern_cache()
+
+    @pytest.mark.parametrize(
+        ("domain_config", "expected_present", "expected_absent", "exact_set", "desc"),
+        INCLUDE_LOADER_CASES,
+        ids=[c[4] for c in INCLUDE_LOADER_CASES],
+    )
+    def test_load_pii_with_inclusions(
+        self,
+        tmp_path: Path,
+        domain_config: dict,
+        expected_present: list[str],
+        expected_absent: list[str],
+        exact_set: bool,
+        desc: str,
+    ) -> None:
+        """Test that include_patterns filters the loaded pattern set."""
+        domain = tmp_path / "domain.json"
+        domain.write_text(json.dumps(domain_config))
+
+        result = load_pii_patterns(str(domain))
+        if exact_set:
+            assert set(result["patterns"]) == set(expected_present), f"{desc}: exact set mismatch"
+        for name in expected_present:
+            assert name in result["patterns"], f"{desc}: {name} should be present"
+        for name in expected_absent:
+            assert name not in result["patterns"], f"{desc}: {name} should be absent"
+
+    @pytest.mark.parametrize(
+        ("domain_config", "content", "expected_detected", "expected_not_detected", "desc"),
+        INCLUDE_PII_CASES,
+        ids=[c[4] for c in INCLUDE_PII_CASES],
+    )
+    def test_check_for_pii_with_inclusions(
+        self,
+        tmp_path: Path,
+        domain_config: dict,
+        content: str,
+        expected_detected: list[str],
+        expected_not_detected: list[str],
+        desc: str,
+    ) -> None:
+        """End-to-end: check_for_pii respects include_patterns from domain file."""
+        from har_capture.sanitization.html import check_for_pii
+
+        domain = tmp_path / "domain.json"
+        domain.write_text(json.dumps(domain_config))
+
+        findings = check_for_pii(content, custom_patterns=str(domain))
+        detected = {f["pattern"] for f in findings}
+        for name in expected_detected:
+            assert name in detected, f"{desc}: {name} should be detected"
+        for name in expected_not_detected:
+            assert name not in detected, f"{desc}: {name} should not be detected"
+
+    def test_dict_custom_with_inclusions(self) -> None:
+        """Inclusions work when custom_path is a dict (not a file)."""
+        result = load_pii_patterns({"include_patterns": ["mac_address", "serial_number"]})
+        assert set(result["patterns"]) == {"mac_address", "serial_number"}
+
+    def test_merge_accumulates_inclusions(self, tmp_path: Path) -> None:
+        """merge_pattern_files extends include_patterns across files."""
+        file_a = tmp_path / "a.json"
+        file_a.write_text(json.dumps({"include_patterns": ["mac_address"]}))
+        file_b = tmp_path / "b.json"
+        file_b.write_text(json.dumps({"include_patterns": ["email"]}))
+
+        merged = merge_pattern_files([file_a, file_b])
+        assert set(merged["include_patterns"]) == {"mac_address", "email"}
 
 
 class TestSensitivePatternsHeuristicsMerge:

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -235,6 +235,393 @@ class TestPostDataSanitization:
         assert result == expected, f"{desc}"
 
 
+# -----------------------------------------------------------------------------
+# Fixture-driven tables for sanitize_post_data(..., custom_patterns=...)
+# -----------------------------------------------------------------------------
+
+CUSTOM_PATTERNS_TEXT_CASES = [
+    (
+        c["id"],
+        c["post_data"],
+        c["custom_patterns"],
+        c["must_contain"],
+        c["must_not_contain"],
+    )
+    for c in _HAR_FIXTURE["custom_patterns_cases"]
+]
+
+CUSTOM_PATTERNS_PARAMS_CASES = [
+    (
+        c["id"],
+        c["params"],
+        c["custom_patterns"],
+        c["expected_values"],
+    )
+    for c in _HAR_FIXTURE["custom_patterns_params_cases"]
+]
+
+
+class TestPostDataCustomPatterns:
+    """Per-call ``custom_patterns`` extension on ``sanitize_post_data``.
+
+    Table-driven: each case in ``tests/fixtures/test_har.json`` under
+    ``custom_patterns_cases`` / ``custom_patterns_params_cases`` exercises one
+    slice of the (MIME type x custom_patterns x field shape) matrix. The
+    fixture is the source of truth for the positive matrix; the standalone
+    methods below cover identities (None vs omission) and invariants that
+    don't fit the table shape.
+    """
+
+    @pytest.mark.parametrize(
+        ("desc", "post_data", "custom_patterns", "must_contain", "must_not_contain"),
+        CUSTOM_PATTERNS_TEXT_CASES,
+        ids=[c[0] for c in CUSTOM_PATTERNS_TEXT_CASES],
+    )
+    def test_text_body_redaction_matrix(
+        self,
+        desc: str,
+        post_data: dict,
+        custom_patterns: dict | None,
+        must_contain: list[str],
+        must_not_contain: list[str],
+    ) -> None:
+        """Exercise form / JSON / XML bodies x (default, custom_patterns)."""
+        result = sanitize_post_data(post_data, custom_patterns=custom_patterns)
+        assert result is not None, desc
+        text = result.get("text", "")
+        for needle in must_contain:
+            assert needle in text, f"{desc}: expected {needle!r} in {text!r}"
+        for needle in must_not_contain:
+            assert needle not in text, f"{desc}: {needle!r} should have been redacted in {text!r}"
+
+    @pytest.mark.parametrize(
+        ("desc", "params", "custom_patterns", "expected_values"),
+        CUSTOM_PATTERNS_PARAMS_CASES,
+        ids=[c[0] for c in CUSTOM_PATTERNS_PARAMS_CASES],
+    )
+    def test_params_redaction_matrix(
+        self,
+        desc: str,
+        params: list[dict],
+        custom_patterns: dict | None,
+        expected_values: dict[str, str],
+    ) -> None:
+        """Exercise postData.params x (default, custom_patterns)."""
+        post_data = {"mimeType": "application/x-www-form-urlencoded", "params": params}
+        result = sanitize_post_data(post_data, custom_patterns=custom_patterns)
+        assert result is not None, desc
+        by_name = {p["name"]: p["value"] for p in result["params"]}
+        for name, expected in expected_values.items():
+            assert by_name[name] == expected, f"{desc}: {name} expected {expected!r}, got {by_name[name]!r}"
+
+    def test_none_matches_omission(self) -> None:
+        """``custom_patterns=None`` produces identical output to omitting the kwarg."""
+        post_data = {
+            "mimeType": "application/x-www-form-urlencoded",
+            "text": "user=admin&password=secret123&pws=alsosecret",
+        }
+        default = sanitize_post_data(post_data)
+        explicit_none = sanitize_post_data(post_data, custom_patterns=None)
+        assert default == explicit_none
+
+    def test_sequential_calls_with_different_patterns_do_not_leak_state(self) -> None:
+        """Sequential calls with differing custom_patterns must not share state.
+
+        Module globals and the ContextVar must not be mutated in a way that
+        changes the output of a subsequent default call.
+        """
+        body = "user=admin&pws=one&loginPassword=two&extra=three"
+
+        def form(text: str) -> dict:
+            return {"mimeType": "application/x-www-form-urlencoded", "text": text}
+
+        # Baseline captured BEFORE any custom_patterns calls.
+        baseline = sanitize_post_data(form(body))
+
+        result_a = sanitize_post_data(
+            form(body),
+            custom_patterns={"fields": {"auto_redact_patterns": ["pws"]}},
+        )
+        result_b = sanitize_post_data(
+            form(body),
+            custom_patterns={"fields": {"auto_redact_patterns": ["extra"]}},
+        )
+
+        # Default call AFTER the custom calls must be identical to the baseline
+        # — proof that neither module globals nor the ContextVar leaked into it.
+        result_default = sanitize_post_data(form(body))
+
+        assert (
+            baseline is not None
+            and result_a is not None
+            and result_b is not None
+            and result_default is not None
+        )
+        assert result_default == baseline
+
+        # A redacts pws but not extra; B redacts extra but not pws.
+        assert "pws=[REDACTED]" in result_a["text"]
+        assert "extra=three" in result_a["text"]
+        assert "extra=[REDACTED]" in result_b["text"]
+        assert "pws=one" in result_b["text"]
+
+        # Built-in loginPassword is redacted in every variant.
+        for r in (baseline, result_a, result_b, result_default):
+            assert "loginPassword=[REDACTED]" in r["text"]
+
+
+# -----------------------------------------------------------------------------
+# Internals — resolver / cache / scope / compiler fallbacks
+# -----------------------------------------------------------------------------
+
+
+# (desc, input_dict, expected_auto_matches, expected_flag_matches_or_none)
+# Each row compiles a sensitive-patterns dict and asserts which names match
+# the resulting auto-redact regex and the flag regex (None when no flag
+# patterns are declared).
+COMPILE_FIELD_PATTERN_CASES = [
+    (
+        "current_schema_both_sections",
+        {"fields": {"auto_redact_patterns": ["pws"], "flag_patterns": ["deployenv"]}},
+        ["pws"],
+        ["deployenv"],
+    ),
+    (
+        "legacy_patterns_key_only",
+        {"fields": {"patterns": ["legacytok"]}},
+        ["legacytok"],
+        None,
+    ),
+    (
+        "hardcoded_fallback_when_fields_empty",
+        {"fields": {}},
+        ["password", "secret", "token", "key", "auth"],
+        None,
+    ),
+    (
+        "hardcoded_fallback_when_fields_missing_entirely",
+        {},
+        ["password", "secret", "token"],
+        None,
+    ),
+]
+
+
+class TestCompileSensitiveFieldPatterns:
+    """Direct coverage for :func:`_compile_sensitive_field_patterns` legacy paths."""
+
+    @pytest.mark.parametrize(
+        ("desc", "sensitive_data", "auto_matches", "flag_matches"),
+        COMPILE_FIELD_PATTERN_CASES,
+        ids=[c[0] for c in COMPILE_FIELD_PATTERN_CASES],
+    )
+    def test_compile_matrix(
+        self,
+        desc: str,
+        sensitive_data: dict,
+        auto_matches: list[str],
+        flag_matches: list[str] | None,
+    ) -> None:
+        from har_capture.sanitization.har import _compile_sensitive_field_patterns
+
+        auto_re, flag_re = _compile_sensitive_field_patterns(sensitive_data)
+        for name in auto_matches:
+            assert auto_re.search(name), f"{desc}: auto regex should match {name!r}"
+        if flag_matches is None:
+            assert flag_re is None, f"{desc}: flag regex should be None"
+        else:
+            assert flag_re is not None, f"{desc}: flag regex should be compiled"
+            for name in flag_matches:
+                assert flag_re.search(name), f"{desc}: flag regex should match {name!r}"
+
+
+class TestFieldPatternSet:
+    """Direct coverage for the :class:`_FieldPatternSet` helper methods."""
+
+    def test_matches_flaggable_returns_false_when_flag_re_is_none(self) -> None:
+        """Guard the explicit None branch in matches_flaggable."""
+        import re as _re
+
+        from har_capture.sanitization.har import _FieldPatternSet
+
+        pset = _FieldPatternSet(field_re=_re.compile("password"), flag_re=None)
+        assert pset.matches_sensitive("password") is True
+        assert pset.matches_flaggable("anything") is False
+
+
+class TestCustomPatternsCacheKey:
+    """Direct coverage for :func:`_custom_patterns_cache_key`."""
+
+    def test_dict_produces_stable_key_regardless_of_insertion_order(self) -> None:
+        from har_capture.sanitization.har import _custom_patterns_cache_key
+
+        a = {"fields": {"auto_redact_patterns": ["pws"], "flag_patterns": ["env"]}}
+        b = {"fields": {"flag_patterns": ["env"], "auto_redact_patterns": ["pws"]}}
+        assert _custom_patterns_cache_key(a) == _custom_patterns_cache_key(b)
+
+    def test_path_input_normalized_to_absolute(self, tmp_path: Path) -> None:
+        from har_capture.sanitization.har import _custom_patterns_cache_key
+
+        path = tmp_path / "does-not-exist.json"
+        key = _custom_patterns_cache_key(str(path))
+        assert key is not None and key.startswith("path:")
+        assert key.endswith("/does-not-exist.json")
+
+    def test_non_serializable_dict_returns_none(self) -> None:
+        """Objects that neither JSON-serialize nor string-coerce return None.
+
+        A None cache key means the caller compiles fresh each call instead of
+        crashing on the unstringifiable dict.
+        """
+        from har_capture.sanitization.har import _custom_patterns_cache_key
+
+        class _Unserializable:
+            def __str__(self) -> str:
+                raise TypeError("refuses to serialize")
+
+        key = _custom_patterns_cache_key({"fields": {"x": _Unserializable()}})
+        assert key is None
+
+
+class TestResolveFieldPatterns:
+    """Direct coverage for :func:`_resolve_field_patterns` caching behavior."""
+
+    def _clear_cache(self) -> None:
+        from har_capture.sanitization.har import _CUSTOM_FIELD_RE_CACHE
+
+        _CUSTOM_FIELD_RE_CACHE.clear()
+
+    def test_none_returns_default_set_without_touching_cache(self) -> None:
+        from har_capture.sanitization.har import (
+            _CUSTOM_FIELD_RE_CACHE,
+            _DEFAULT_FIELD_PATTERNS,
+            _resolve_field_patterns,
+        )
+
+        self._clear_cache()
+        result = _resolve_field_patterns(None)
+        assert result is _DEFAULT_FIELD_PATTERNS
+        assert len(_CUSTOM_FIELD_RE_CACHE) == 0
+
+    def test_same_dict_returns_cached_instance(self) -> None:
+        from har_capture.sanitization.har import _resolve_field_patterns
+
+        self._clear_cache()
+        custom = {"fields": {"auto_redact_patterns": ["pws"]}}
+        first = _resolve_field_patterns(custom)
+        second = _resolve_field_patterns(custom)
+        assert first is second, "second call should hit the cache and return the same instance"
+
+    def test_different_dicts_produce_different_instances(self) -> None:
+        from har_capture.sanitization.har import _resolve_field_patterns
+
+        self._clear_cache()
+        a = _resolve_field_patterns({"fields": {"auto_redact_patterns": ["pws"]}})
+        b = _resolve_field_patterns({"fields": {"auto_redact_patterns": ["extra"]}})
+        assert a is not b
+        assert a.matches_sensitive("pws") and not b.matches_sensitive("pws")
+        assert b.matches_sensitive("extra") and not a.matches_sensitive("extra")
+
+    def test_cache_eviction_bounded_by_max(self) -> None:
+        """Cache size is capped at _CUSTOM_FIELD_RE_CACHE_MAX entries.
+
+        When exceeded, the oldest entry is evicted so the dict never grows
+        unboundedly.
+        """
+        from har_capture.sanitization.har import (
+            _CUSTOM_FIELD_RE_CACHE,
+            _CUSTOM_FIELD_RE_CACHE_MAX,
+            _resolve_field_patterns,
+        )
+
+        self._clear_cache()
+        for i in range(_CUSTOM_FIELD_RE_CACHE_MAX + 5):
+            _resolve_field_patterns({"fields": {"auto_redact_patterns": [f"p{i}"]}})
+
+        assert len(_CUSTOM_FIELD_RE_CACHE) == _CUSTOM_FIELD_RE_CACHE_MAX
+
+
+class TestFieldPatternsScope:
+    """Direct coverage for the :func:`_field_patterns_scope` context manager."""
+
+    def test_scope_restores_previous_value_on_normal_exit(self) -> None:
+        from har_capture.sanitization.har import (
+            _DEFAULT_FIELD_PATTERNS,
+            _FIELD_PATTERNS_CTX,
+            _field_patterns_scope,
+        )
+
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS
+        with _field_patterns_scope({"fields": {"auto_redact_patterns": ["pws"]}}):
+            assert _FIELD_PATTERNS_CTX.get().matches_sensitive("pws")
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS
+
+    def test_scope_restores_previous_value_on_exception(self) -> None:
+        from har_capture.sanitization.har import (
+            _DEFAULT_FIELD_PATTERNS,
+            _FIELD_PATTERNS_CTX,
+            _field_patterns_scope,
+        )
+
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            _field_patterns_scope({"fields": {"auto_redact_patterns": ["pws"]}}),
+        ):
+            raise RuntimeError("boom")
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS
+
+    def test_nested_scopes_stack_correctly(self) -> None:
+        from har_capture.sanitization.har import (
+            _FIELD_PATTERNS_CTX,
+            _field_patterns_scope,
+        )
+
+        with _field_patterns_scope({"fields": {"auto_redact_patterns": ["outer"]}}):
+            outer = _FIELD_PATTERNS_CTX.get()
+            assert outer.matches_sensitive("outer")
+            assert not outer.matches_sensitive("inner")
+            with _field_patterns_scope({"fields": {"auto_redact_patterns": ["inner"]}}):
+                inner = _FIELD_PATTERNS_CTX.get()
+                assert inner.matches_sensitive("inner")
+            # Inner scope exited — outer set is restored.
+            assert _FIELD_PATTERNS_CTX.get() is outer
+
+
+class TestContextVarIsolatesThreads:
+    """The ContextVar must not bleed between concurrent threads."""
+
+    def test_concurrent_threads_see_independent_patterns(self) -> None:
+        import threading
+
+        from har_capture.sanitization.har import (
+            _FIELD_PATTERNS_CTX,
+            _field_patterns_scope,
+        )
+
+        barrier = threading.Barrier(2)
+        results: dict[str, bool] = {}
+
+        def worker(name: str, custom_field: str) -> None:
+            with _field_patterns_scope({"fields": {"auto_redact_patterns": [custom_field]}}):
+                barrier.wait()  # both threads enter their scopes before any checks run
+                results[name] = _FIELD_PATTERNS_CTX.get().matches_sensitive(custom_field)
+                results[f"{name}_cross"] = _FIELD_PATTERNS_CTX.get().matches_sensitive("zzz_other_field")
+
+        t1 = threading.Thread(target=worker, args=("t1", "aaa_only_t1"))
+        t2 = threading.Thread(target=worker, args=("t2", "bbb_only_t2"))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert results["t1"] is True
+        assert results["t2"] is True
+        # Neither thread sees the other's field — the ContextVar is isolated.
+        assert results["t1_cross"] is False
+        assert results["t2_cross"] is False
+
+
 class TestEntrySanitization:
     """Tests for full HAR entry sanitization."""
 

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -306,6 +306,118 @@ class TestSetItemScanning:
         assert "config_data" in result, "key name should be preserved"
 
 
+_CUSTOM_PWS = {"fields": {"auto_redact_patterns": ["pws"]}}
+
+# (desc, html, custom_patterns, must_contain, must_not_contain)
+# Each row asserts that the setItem scanner honors (or ignores) custom_patterns
+# via the field-pattern ContextVar scope.
+SANITIZE_HTML_CUSTOM_PATTERN_CASES = [
+    (
+        "unknown_key_preserved_by_default",
+        'localStorage.setItem("pws", "alsosecret")',
+        None,
+        ["alsosecret"],
+        [],
+    ),
+    (
+        "unknown_key_redacted_with_custom",
+        'localStorage.setItem("pws", "alsosecret")',
+        _CUSTOM_PWS,
+        ["pws"],
+        ["alsosecret"],
+    ),
+    (
+        "sessionstorage_custom_key_redacted",
+        'sessionStorage.setItem("pws", "alsosecret")',
+        _CUSTOM_PWS,
+        ["pws"],
+        ["alsosecret"],
+    ),
+    (
+        "builtin_sensitive_key_still_redacts_with_custom",
+        'localStorage.setItem("PrivateKey", "secret_value_123")',
+        _CUSTOM_PWS,
+        ["PrivateKey"],
+        ["secret_value_123"],
+    ),
+    (
+        "unrelated_key_unaffected_by_custom",
+        'localStorage.setItem("safeKey", "benign_value")',
+        _CUSTOM_PWS,
+        ["safeKey", "benign_value"],
+        [],
+    ),
+]
+
+
+class TestSanitizeHtmlCustomFieldPatterns:
+    """Regression tests for sanitize_html honoring custom field patterns.
+
+    sanitize_html's internal ``is_sensitive_field`` calls must honor
+    ``custom_patterns`` via the field-pattern context scope. Guards against the
+    prior bug where ``custom_patterns`` was loaded but the setItem scanner
+    still used the module-global field regex.
+    """
+
+    @pytest.mark.parametrize(
+        ("desc", "html", "custom_patterns", "must_contain", "must_not_contain"),
+        SANITIZE_HTML_CUSTOM_PATTERN_CASES,
+        ids=[c[0] for c in SANITIZE_HTML_CUSTOM_PATTERN_CASES],
+    )
+    def test_setitem_redaction_matrix(
+        self,
+        desc: str,
+        html: str,
+        custom_patterns: dict | None,
+        must_contain: list[str],
+        must_not_contain: list[str],
+    ) -> None:
+        """Table-driven: setItem scanner x (default, custom_patterns)."""
+        result = sanitize_html(html, salt=None, custom_patterns=custom_patterns)
+        for needle in must_contain:
+            assert needle in result, f"{desc}: expected {needle!r} in {result!r}"
+        for needle in must_not_contain:
+            assert needle not in result, f"{desc}: {needle!r} should be redacted in {result!r}"
+
+    def test_context_scope_does_not_leak_out(self) -> None:
+        """After a custom_patterns call, a subsequent default call must behave as default."""
+        custom_html = 'localStorage.setItem("pws", "alsosecret")'
+        default_html = 'localStorage.setItem("pws", "baseline_value")'
+
+        sanitize_html(custom_html, salt=None, custom_patterns=_CUSTOM_PWS)
+        result_after = sanitize_html(default_html, salt=None)
+
+        assert "baseline_value" in result_after, (
+            "Default call after a custom_patterns call must NOT inherit the override"
+        )
+
+    def test_scope_restored_when_inner_call_raises(self) -> None:
+        """sanitize_html's try/finally must reset the ContextVar even on exception."""
+        from unittest.mock import patch
+
+        from har_capture.sanitization.har import (
+            _DEFAULT_FIELD_PATTERNS,
+            _FIELD_PATTERNS_CTX,
+        )
+
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS
+
+        # Force the inner impl to blow up; the outer sanitize_html must still
+        # clean up the ContextVar.
+        with (
+            patch(
+                "har_capture.sanitization.html._sanitize_html_impl",
+                side_effect=RuntimeError("inner boom"),
+            ),
+            pytest.raises(RuntimeError, match="inner boom"),
+        ):
+            sanitize_html("<html></html>", salt=None, custom_patterns=_CUSTOM_PWS)
+
+        assert _FIELD_PATTERNS_CTX.get() is _DEFAULT_FIELD_PATTERNS, (
+            "sanitize_html must reset the ContextVar even when the inner impl raises"
+        )
+
+
 # =============================================================================
 # Serial Numbers in Pipe-Delimited Strings (Gap 2 fix)
 # =============================================================================


### PR DESCRIPTION
## Summary

Two additive features plus a loader fix, shipping as 0.7.0.

- **`include_patterns` in domain pattern files** (from 0572cd2 on this branch, pre-existing). Domain files can declare which `pii.patterns` entries they want, and the loader filters the merged set. Prevents false positives like credit-card regexes triggering on cable-modem duration floats. `network_device.json` ships with this list.
- **Per-call `custom_patterns` extends field-name detection in `sanitize_post_data` and `sanitize_html`.** Consumer-side runtime field lists (e.g. Cable Modem Monitor's per-modem credential field names) now work without editing universal patterns. Implemented via a `ContextVar`-scoped override read by `is_sensitive_field` / `is_flaggable_field`; inner helper signatures unchanged. Thread- and asyncio-isolated by construction. Additive (built-ins still apply). Compiled regex pairs cached per canonical key.
- **Loader fix: `fields.auto_redact_patterns` and `fields.flag_patterns` now merge from custom-patterns dicts.** Previously only the legacy `fields.patterns` key merged, and the compiler ignored that key when `auto_redact_patterns` was present — so the current-schema shape was a silent no-op. File-path consumers who were bitten will now see their extensions apply.

Also fixes a latent `sanitize_html` gap (its internal `is_sensitive_field` call used module-global patterns even when `custom_patterns` was passed) as a side effect of the ContextVar refactor.

**Stats**: 1833 tests / 85.45% coverage. 18 files, +1334/-53. Pre-commit hooks (ruff, ruff-format, mypy, detect-secrets, mdformat, commitizen) all green.

**Docs updated**: `CUSTOM_PATTERNS.md` (new "Extending Sensitive Field Detection" section), `USE_CASES.md` (UC-42 for the CMM runtime-catalog pattern), `ARCHITECTURE.md` (two-extension-points paragraph), `SANITIZATION_SPEC.md`, `PATTERN_SPEC.md`, `README.md` pointer, and docstrings on every public `sanitize_*` entry point.

**⚠️ Before merging**: the CHANGELOG `[0.7.0]` section documents the `custom_patterns` feature and the loader fix, but does NOT yet mention `include_patterns` (Ken's 0572cd2 commit on this branch). Worth patching before tag.

## Test plan

- [ ] CI green on Python 3.10–3.13
- [ ] Coverage ≥ 75% (currently 85.45%)
- [ ] Manual: confirm downstream Cable Modem Monitor can replace its `_redact_form_field_values` pre-pass with `sanitize_post_data(..., custom_patterns={"fields": {"auto_redact_patterns": [catalog_fields...]}})` once 0.7.0 is on PyPI
- [ ] CHANGELOG decision: add `include_patterns` entry to `[0.7.0]` section before tagging, or leave it

🤖 Generated with [Claude Code](https://claude.com/claude-code)