### PR TITLE
feat(capture): auto-detect HTTP vs HTTPS for bare hostnames (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-01
+
+### Changed
+
+- **Bare hostnames/IPs now auto-detect HTTP vs HTTPS** — `har-capture <target>` and `check_device_connectivity(target)` accept a bare hostname/IP again. When no scheme is provided, a stdlib-only TCP+TLS probe of `:80` and `:443` runs first; HTTPS is preferred when its handshake completes. Reverses the 0.6.0 hard rejection of bare hostnames, which traded ambiguity for a contributor trap: guessing `http://` on an HTTPS-only device misses the auth challenge that lives on `:443`. Explicit schemes still bypass detection entirely — the user has chosen.
+
+### Added
+
+- **`detect_protocol()` + `ProtocolDetectionResult`** — New stdlib-only protocol detection in `har_capture.capture.connectivity`. Probes TCP `:80` and `:443`; if `:443` accepts a TCP connection *and* completes a TLS handshake, HTTPS wins. The handshake uses a `SECLEVEL=0` cipher context so it succeeds against legacy modems (TLS 1.0/1.1, 3DES/RC4) — without that tolerance, we'd false-fail HTTPS and silently capture an HTTP redirect stub instead of the auth challenge, the inverse of the CM1200 trap this whole feature exists to close. har-capture does not classify or surface the negotiated TLS version (Chromium runs its own TLS stack and har-capture cannot act on the classification); the version is logged for diagnostics only. Helpers `_strip_protocol`, `_split_host_port`, `_tcp_probe`, `_tls_handshake` are exposed for direct testing. Adapted from `cable_modem_monitor_core/connectivity.py` (both projects owned by solentlabs); duplicated rather than shared so har-capture's runtime stays stdlib-only and CMM Core does not pull playwright via a shared package. `getaddrinfo` defaults to IPv4 (avoids dual-stack false-fails on consumer LAN devices) but bracketed IPv6 literals (`[::1]:8443`) auto-select `AF_INET6` so v6-only targets are not silently dropped. Explicit `:port` overrides and case-insensitive scheme prefixes (`HTTPS://...`) are supported.
+- **Table-driven `DETECT_PROTOCOL_CASES` test bench** — 12 rows covering HTTP-only, HTTPS-handshake-completes, handshake-fails-falls-back-to-HTTP, both-closed, explicit-scheme-skip-half, custom-port, and bracketed IPv6 (HTTP-only and HTTPS-with-port). Adding a row adds a test.
+
+### Changed (internal cleanup)
+
+- **`_parse_target` is now a thin wrapper over `_strip_protocol`** — Eliminates the parallel-helper duplication left over from the v0.8.0 port. Public callers (`browser.py`, `workflow.py`) keep the `(host, scheme)` tuple shape; new code in `connectivity.py` uses `_strip_protocol` directly. Drops the unused `urllib.parse.urlparse` import. Non-http/https schemes (`ftp://`, etc.) are now returned with `scheme=None` since har-capture cannot capture them anyway — previously `_parse_target("ftp://x")` returned `("x", "ftp")` and the connectivity check immediately fell through to auto-detect, producing the same outcome via a different code path.
+
 ## [0.7.1] - 2026-04-24
 
 ### Fixed
@@ -496,4 +511,5 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.6.1]: https://github.com/solentlabs/har-capture/compare/v0.6.0...v0.6.1
 [0.7.0]: https://github.com/solentlabs/har-capture/compare/v0.6.1...v0.7.0
 [0.7.1]: https://github.com/solentlabs/har-capture/compare/v0.7.0...v0.7.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.7.1...HEAD
+[0.8.0]: https://github.com/solentlabs/har-capture/compare/v0.7.1...v0.8.0
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.8.0...HEAD

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -32,9 +32,12 @@ HTTP requests. The browser handles auth dialogs, redirects, and errors
 naturally — the user is present to respond.
 
 - **Connectivity check (1 GET):** Retained. Validates the device is reachable
-  on the user-provided scheme before launching Playwright. The URL must
-  include an explicit `http://` or `https://` scheme. Without the check,
-  Playwright would hang silently on unreachable devices.
+  before launching Playwright; without the check, Playwright would hang
+  silently on unreachable devices. The original 0.6.0 form required an
+  explicit `http://` or `https://` scheme — this was reversed in 0.8.0
+  after the CM1200 trap (contributor guesses HTTP, misses HTTPS-only auth
+  challenge). Bare hostnames now auto-detect via TCP+TLS probes; explicit
+  schemes still bypass detection. See ADR-10.
 - **Auth detection:** Not needed in interactive mode. When a device responds
   with 401, Playwright shows a native Basic Auth dialog. The user enters
   credentials. Both the 401 and the authenticated retry are captured in the
@@ -198,3 +201,61 @@ The login flow is missing, making the HAR useless for auth analysis.
 check). `--minimal` skips it for session-constrained devices. The
 pre-capture cookie audit has zero network cost — it reads local context
 state. All three defenses are additive and composable.
+
+## ADR-10: Auto-Detect Protocol for Bare Hostnames (supersedes 0.6.0 explicit-scheme rule)
+
+**Context:** v0.6.0 hardened the connectivity phase to require an
+explicit `http://` or `https://` scheme, rejecting bare hostnames with a
+"Missing scheme" error. The intent was to eliminate ambiguity and avoid
+duplicate connectivity probes. In practice this restored a contributor
+trap that v0.4.4's raw-probe feature had originally been built to
+diagnose: cable_modem_monitor #121 (CM1200) closed only after weeks of
+debugging because the device serves its auth challenge on `:443` and
+silently 200s on `:80`. A contributor guessing `http://` captures a
+useless redirect stub; a contributor guessing `https://` captures the
+real auth flow. The "helpful error" the v0.6.0 rejection produces does
+not help — both choices look equally plausible at the CLI.
+
+**Decision:** When the target lacks an explicit scheme, auto-detect via
+stdlib TCP+TLS probes. Probe `:80` and `:443`; prefer HTTPS when its
+TCP connection accepts *and* the TLS handshake completes. Explicit
+schemes still bypass detection — the user has chosen and we do not
+second-guess.
+
+The probe code is adapted from `cable_modem_monitor_core/connectivity.py`
+(both projects owned by solentlabs). It is duplicated, not shared, so
+har-capture's runtime stays stdlib-only — CMM Core's `requests`/`urllib3`
+deps would land in every har-capture install, and a shared package would
+also drag playwright into CMM Core's tree.
+
+The implementation defaults `getaddrinfo` to IPv4: most consumer devices
+are IPv4-only on the LAN side, and a dual-stack resolver may otherwise
+return IPv6 first and false-fail before falling back. Bracketed IPv6
+input (`[::1]:8443`) is treated as the user's explicit v6 signal and
+auto-selects `AF_INET6` for the probe — capture-everything beats default-
+to-fail when the user is asking us to look at v6. Unbracketed inputs
+that happen to contain colons stay on AF_INET (heuristic IPv6 detection
+on bare strings is too risky to do silently). The TLS handshake uses a
+`SECLEVEL=0` cipher context so it completes against legacy devices (TLS
+1.0/1.1, 3DES/RC4) — this tolerance is the entire point. Without it, we
+would false-fail HTTPS on old modems and incorrectly fall back to HTTP,
+inverting the trap this feature exists to close.
+
+har-capture deliberately does **not** classify or surface the negotiated
+TLS version. Unlike CMM Core (whose `requests`-based runtime can mount a
+`LegacySSLAdapter` to keep polling working), har-capture's runtime is
+Chromium driven by Playwright — we don't control its TLS stack and
+cannot act on a "legacy" classification. Carrying that flag would be
+ceremony without consequence. The version is logged for diagnostics so
+operators tailing logs can see what got negotiated, but the
+`ProtocolDetectionResult` returns only `success`/`protocol`/`working_url`/
+`error`. This is a deliberate divergence from CMM Core, recorded here so
+future re-syncs do not reintroduce the flag.
+
+**Consequence:** Bare hostnames work again (`har-capture 192.168.100.1`).
+The CM1200 trap is closed by default, and the inverse trap (false-failing
+HTTPS on legacy devices) is closed by the cipher tolerance. One additional
+pre-flight TCP probe in the bare-hostname path (the TCP connect on the
+unused port — closed ports return immediately, so latency is bounded by
+`timeout`). When an explicit scheme is given, behavior is byte-identical
+to v0.7.x.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -12,7 +12,7 @@ ______________________________________________________________________
 
 Capture HTTP traffic using a browser. **By default, the output is sanitized and compressed** - you get a single `.sanitized.har.gz` file ready to share.
 
-`get` is the default command — you can omit it when the first argument is a URL. The URL must include a scheme (`http://` or `https://`).
+`get` is the default command — you can omit it when the first argument is a URL. The target may be a full URL (`http://`/`https://`) or a bare hostname/IP; when the scheme is omitted, har-capture probes TCP `:80` and `:443` and prefers HTTPS when its TLS handshake completes (see ADR-10).
 
 ### Basic Usage
 
@@ -23,7 +23,7 @@ har-capture get <TARGET>
 
 ### Arguments
 
-- `TARGET` - URL with scheme (`http://` or `https://`)
+- `TARGET` - URL (`http://` or `https://`), bare hostname/IP, or `host:port`. Scheme is auto-detected when omitted.
 
 ### Options
 
@@ -59,6 +59,9 @@ har-capture https://example.com
 # Explicit 'get' subcommand (equivalent)
 har-capture get https://example.com
 
+# Bare hostname — scheme auto-detected (HTTPS preferred when reachable)
+har-capture 192.168.100.1
+
 # Custom output path
 har-capture http://192.168.1.1 --output modem.har
 
@@ -76,7 +79,7 @@ har-capture https://example.com --no-wait-for-data
 
 Before launching the browser, `get` runs two checks (skipped with `--minimal`):
 
-1. **Connectivity** — validates the target is reachable on the given scheme
+1. **Connectivity** — validates the target is reachable. If the target lacks a scheme, har-capture probes TCP `:80` and `:443` to pick HTTP vs HTTPS (HTTPS wins when its TLS handshake completes); explicit schemes bypass this and are used as given.
 
 1. **Session contamination** — detects if the device has a live session that would skip the login flow. If the device returns data content without requiring authentication, the capture aborts with:
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -60,9 +60,9 @@ ______________________________________________________________________
 
 **Flow**:
 
-1. User runs capture command targeting the device (URL must include `http://` or `https://`)
+1. User runs capture command targeting the device (full URL with `http://`/`https://`, or a bare hostname/IP)
 1. System checks browser availability
-1. System checks device connectivity on the provided scheme
+1. System checks device connectivity. If the user did not supply a scheme, system probes TCP `:80` and `:443` and prefers HTTPS when its TLS handshake completes (see ADR-10); explicit schemes are used as given
 1. System checks for session contamination — aborts if the device has a live session (serves data without login)
 1. System launches Playwright browser with a clean context (empty cookie jar), navigates to device URL
 1. Browser records all HTTP traffic to a temp HAR file with embedded response bodies
@@ -83,6 +83,10 @@ ______________________________________________________________________
 **CLI Example**:
 
 ```bash
+# Scheme auto-detected (HTTPS preferred when reachable)
+har-capture 192.168.1.1
+
+# Explicit scheme bypasses auto-detection
 har-capture http://192.168.1.1
 har-capture http://192.168.100.1 --output modem_capture.har
 ```
@@ -545,7 +549,7 @@ ______________________________________________________________________
 
 1. User runs capture with `--minimal` flag
 1. System checks browser availability (Phase 1)
-1. System checks connectivity with a single GET (Phase 2) — determines http/https scheme
+1. System checks connectivity with a single GET — auto-detects http/https when no scheme is provided (TCP+TLS probe; HTTPS preferred), or uses the explicit scheme as given
 1. Session check, probes, and auth check are **skipped** — no additional HTTP requests
 1. Browser opens with a clean context and `domcontentloaded` page load strategy (no `networkidle` wait)
 1. Wait-for-data XHR/fetch tracking is disabled
@@ -556,7 +560,7 @@ ______________________________________________________________________
 
 - Device needs Basic Auth → provide `--username`/`--password` on command line (auth check phase is skipped, credentials passed directly to Playwright)
 - Device uses form-based auth → user logs in through the browser UI (captured in HAR)
-- Even `--minimal` connectivity check triggers lockout → user can provide explicit scheme: `http://192.168.100.1`
+- Even `--minimal` connectivity check triggers lockout → user can provide an explicit scheme (`http://192.168.100.1`) to skip the auto-detect TCP+TLS probes
 
 **CLI Example**:
 

--- a/docs/specs/CAPTURE_SPEC.md
+++ b/docs/specs/CAPTURE_SPEC.md
@@ -11,7 +11,7 @@ This spec describes the full Playwright-based capture lifecycle — from browser
 | `src/har_capture/capture/browser.py`      | Core capture orchestration: Playwright session, wait-for-data, HAR recording, state capture, filtering/compression |
 | `src/har_capture/capture/workflow.py`     | Multi-phase workflow: browser check → connectivity → probes → auth → capture                                       |
 | `src/har_capture/capture/probes.py`       | Pre-capture diagnostics: auth challenge, HEAD support, ICMP ping                                                   |
-| `src/har_capture/capture/connectivity.py` | Reachability check (requires explicit scheme), Basic Auth detection                                                |
+| `src/har_capture/capture/connectivity.py` | Reachability check, protocol auto-detection (TCP+TLS probe), Basic Auth detection                                  |
 | `src/har_capture/capture/deps.py`         | Browser installation and system dependency checking                                                                |
 | `src/har_capture/cli/capture.py`          | CLI `har-capture get` command, interactive prompts                                                                 |
 
@@ -40,12 +40,16 @@ result = check_connectivity_phase(target, result)
 `check_device_connectivity()` in `connectivity.py` sends an unauthenticated GET request via stdlib urllib:
 
 1. Parse target via `_parse_target()` — handles URLs with schemes (including IPv6 with brackets, ports)
-1. Require an explicit scheme (`http://` or `https://`); bare hostnames/IPs are rejected with a helpful error
-1. Send a single GET to `{scheme}://{host}/`
+1. If no scheme is provided, run `detect_protocol()` (see below) to choose between HTTP and HTTPS via TCP+TLS probes; if both transports fail, return the detection error
+1. Send a single GET to `{scheme}://{host}/` (using either the provided or detected scheme)
 1. Any response (including 401/403) = reachable
 1. Self-signed certificates accepted via `make_ssl_context()` (`check_hostname=False, verify_mode=CERT_NONE`)
 
-Returns `(reachable, scheme, error)`.
+Returns `(reachable, scheme, error)`. Explicit schemes bypass auto-detection — the user has chosen.
+
+#### Protocol auto-detection (`detect_protocol`)
+
+Stdlib-only protocol probe used when the target lacks an explicit scheme. Probes TCP `:80` and `:443`; if `:443` accepts a TCP connection *and* completes a TLS handshake, HTTPS wins — devices that expose both ports almost always intend HTTPS for authenticated traffic, and `:80` is typically a redirect or legacy stub. The handshake uses a `SECLEVEL=0` cipher context so it completes against legacy devices (TLS 1.0/1.1, 3DES/RC4) — this tolerance is load-bearing: without it, the probe would false-fail HTTPS on old modems and capture HTTP instead. `getaddrinfo` defaults to `AF_INET` (protects against dual-stack false-fail on IPv4-only LAN devices); bracketed IPv6 input (`[::1]:8443`) auto-selects `AF_INET6` so v6-only targets are not silently dropped. Scheme matching is case-insensitive. If the user supplies an explicit `:port` (e.g. `127.0.0.1:8443`), only that port is probed. Returns a `ProtocolDetectionResult` with `success`, `protocol`, `working_url`, and `error`. The negotiated TLS version is logged for diagnostics but not classified or surfaced — har-capture cannot act on it (Chromium runs its own TLS stack); see ADR-10 for the rationale. Adapted from `cable_modem_monitor_core/connectivity.py` and intentionally duplicated rather than shared so har-capture's runtime stays stdlib-only.
 
 ### Phase 3: Session Contamination Check (`check_session_phase`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.7.1"
+version = "0.8.0"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/capture/connectivity.py
+++ b/src/har_capture/capture/connectivity.py
@@ -2,19 +2,29 @@
 
 This module provides functions to check target reachability and authentication
 requirements before launching the browser capture.
+
+Protocol detection (``detect_protocol`` and helpers) is adapted from
+``cable_modem_monitor_core/connectivity.py`` — both projects are owned
+by solentlabs; the code is duplicated rather than shared so har-capture
+can keep its stdlib-only runtime (CMM Core depends on requests/urllib3,
+and har-capture must not pull playwright into CMM).
 """
 
 from __future__ import annotations
 
 import logging
+import socket
+import ssl
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlparse
 
 from har_capture.capture.probes import make_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_DETECT_TIMEOUT = 5.0
 
 # Response body indicators that a login/authentication page is being served.
 # If none of these appear in a 200 response, the device likely has a live
@@ -58,6 +68,13 @@ def _urlopen_with_ssl(
 def _parse_target(target: str) -> tuple[str, str | None]:
     """Parse a target string into hostname and optional scheme.
 
+    Thin compatibility wrapper around :func:`_strip_protocol` for callers
+    that want the ``(host, scheme)`` tuple shape (browser.py, workflow.py).
+    New code in this module should call ``_strip_protocol`` directly to
+    avoid the internal transposition. Recognizes only ``http``/``https``
+    as schemes; other schemes (``ftp://`` etc.) are returned as the bare
+    string with ``scheme=None`` since har-capture cannot capture them.
+
     Handles various input formats:
     - Full URL: "https://example.com" -> ("example.com", "https")
     - URL with path: "https://example.com/page" -> ("example.com", "https")
@@ -66,48 +83,273 @@ def _parse_target(target: str) -> tuple[str, str | None]:
     - IP with port: "192.168.1.1:8080" -> ("192.168.1.1:8080", None)
     - IPv6 address: "[::1]" -> ("[::1]", None)
     - IPv6 URL: "https://[::1]:8443/page" -> ("[::1]:8443", "https")
+    """
+    scheme, host = _strip_protocol(target)
+    return host, scheme
+
+
+# ---------------------------------------------------------------------------
+# Protocol detection — adapted from cable_modem_monitor_core/connectivity.py
+# ---------------------------------------------------------------------------
+
+# Permissive cipher string for the probe handshake. ``SECLEVEL=0`` disables
+# OpenSSL security-level checks, permitting legacy ciphers (3DES, RC4) and
+# protocol versions (TLS 1.0/1.1) that older device firmware requires. The
+# probe's job is to confirm HTTPS is reachable so the *browser* drives the
+# session — har-capture cannot act on TLS-version classification (Chromium
+# has its own stack), so we don't classify, we just complete.
+_LEGACY_CIPHERS = "DEFAULT:@SECLEVEL=0"
+
+
+@dataclass
+class ProtocolDetectionResult:
+    """Result of :func:`detect_protocol`.
+
+    Attributes:
+        success: True if the target responded on at least one transport.
+        protocol: ``"http"`` or ``"https"`` — whichever was selected.
+        working_url: Full URL that responded (e.g. ``https://192.168.100.1``).
+        error: Human-readable message when ``success`` is False.
+    """
+
+    success: bool
+    protocol: str | None = None
+    working_url: str | None = None
+    error: str | None = None
+
+
+def _strip_protocol(host: str) -> tuple[str | None, str]:
+    """Split an optional protocol prefix from a host string.
+
+    Scheme matching is case-insensitive (``HTTPS://...`` is recognized
+    same as ``https://...``) — RFC 3986 makes the scheme component
+    case-insensitive, and capture targets pasted from documentation
+    should not silently fall through to bare-hostname auto-detection.
+
+    Returns ``(protocol, bare_host)``. ``protocol`` is ``"http"`` or
+    ``"https"`` if the input had a prefix, else None. ``bare_host``
+    may still include a ``:port`` suffix and preserves the original
+    case of the host portion.
+    """
+    lower = host.lower()
+    for prefix, name in (("http://", "http"), ("https://", "https")):
+        if lower.startswith(prefix):
+            bare = host[len(prefix) :].split("/", 1)[0]
+            return (name, bare)
+    return (None, host.split("/", 1)[0])
+
+
+def _split_host_port(host: str) -> tuple[str, int | None]:
+    """Split ``host:port`` into ``(hostname, port)``.
+
+    Returns ``(host, None)`` when the input has no port suffix.
+    Bracketed IPv6 literals (``[::1]:8080``) are handled — the bracket
+    form is the only safe way to disambiguate IPv6 from a bare
+    ``host:port`` colon.
+    """
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            return (host, None)
+        hostname = host[1:end]
+        tail = host[end + 1 :]
+        if tail.startswith(":") and tail[1:].isdigit():
+            return (hostname, int(tail[1:]))
+        return (hostname, None)
+    if ":" in host:
+        head, _, tail = host.rpartition(":")
+        if tail.isdigit():
+            return (head, int(tail))
+    return (host, None)
+
+
+def _tcp_probe(
+    host: str,
+    port: int,
+    timeout: float,
+    *,
+    address_family: int = socket.AF_INET,
+) -> bool:
+    """Return True if ``host:port`` accepts a TCP connection.
+
+    Defaults to IPv4 — most consumer devices are IPv4-only on the LAN
+    side, and a dual-stack ``getaddrinfo`` may otherwise return IPv6
+    first and false-fail the probe before falling back to v4. The
+    caller passes ``address_family=socket.AF_INET6`` when the input is
+    explicit IPv6 (a bracketed literal like ``[::1]:8443``) so we don't
+    silently drop captures of IPv6-only targets — capture-everything
+    over false-fail.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, family=address_family, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        _LOGGER.debug("TCP probe %s:%d — address resolution failed: %s", host, port, exc)
+        return False
+
+    for family, socktype, proto, _canon, sockaddr in infos:
+        sock = socket.socket(family, socktype, proto)
+        sock.settimeout(timeout)
+        try:
+            sock.connect(sockaddr)
+            return True
+        except (OSError, TimeoutError) as exc:
+            _LOGGER.debug("TCP probe %s:%d failed: %s", host, port, exc)
+        finally:
+            sock.close()
+    return False
+
+
+def _tls_handshake(host: str, port: int, timeout: float) -> bool:
+    """Open a TLS connection with broad ciphers and report whether it completed.
+
+    Uses a ``SECLEVEL=0`` cipher context so the handshake succeeds against
+    legacy devices (TLS 1.0/1.1, 3DES/RC4 ciphers). Without this tolerance,
+    we'd fail the probe on old modems and incorrectly fall back to HTTP —
+    the inverse of the CM1200 trap. The negotiated version is logged for
+    diagnostics but not classified, since har-capture cannot act on it
+    (Chromium runs its own TLS stack).
+    """
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    context.set_ciphers(_LEGACY_CIPHERS)
+
+    try:
+        with (
+            socket.create_connection((host, port), timeout=timeout) as raw_sock,
+            context.wrap_socket(raw_sock, server_hostname=host) as tls_sock,
+        ):
+            _LOGGER.info(
+                "TLS probe %s:%d — negotiated %s",
+                host,
+                port,
+                tls_sock.version() or "unknown",
+            )
+            return True
+    except (ssl.SSLError, OSError, TimeoutError) as exc:
+        _LOGGER.debug("TLS handshake to %s:%d failed: %s", host, port, exc)
+        return False
+
+
+def detect_protocol(
+    host: str,
+    *,
+    timeout: float = _DEFAULT_DETECT_TIMEOUT,
+) -> ProtocolDetectionResult:
+    """Detect the working protocol for a target.
+
+    Probes TCP ``:80`` and ``:443``. If ``:443`` accepts connections
+    *and* completes a TLS handshake, prefers HTTPS — devices that
+    expose both ports almost always intend HTTPS for authenticated
+    traffic, and ``:80`` is typically a redirect or legacy stub.
+
+    If *host* already includes a protocol prefix (``http://`` or
+    ``https://``), only that transport is probed — the user has
+    explicitly chosen.
 
     Args:
-        target: URL, hostname, or IP address
+        host: IP address, hostname, or full URL.
+        timeout: Per-probe timeout in seconds (applied to each TCP
+            probe and the TLS handshake separately).
 
     Returns:
-        Tuple of (hostname_with_port, scheme_or_none)
+        :class:`ProtocolDetectionResult` describing the chosen transport.
     """
-    # Check if it looks like a URL (has scheme)
-    if "://" in target:
-        parsed = urlparse(target)
-        host = parsed.netloc or parsed.path.split("/")[0]
-        return host, parsed.scheme
-    # No scheme - return as-is
-    return target, None
+    explicit_protocol, bare_host = _strip_protocol(host)
+    # Bracketed input (``[::1]``, ``[fe80::1]:8443``) is the user's explicit
+    # IPv6 signal — keep the IPv4 pin for everything else so dual-stack
+    # ``getaddrinfo`` doesn't false-fail on consumer LAN devices that only
+    # answer on v4. ``socket.create_connection`` inside ``_tls_handshake``
+    # already handles both families via its default unspecified resolution.
+    address_family = socket.AF_INET6 if bare_host.startswith("[") else socket.AF_INET
+    hostname, port_override = _split_host_port(bare_host)
+    http_port = port_override or 80
+    https_port = port_override or 443
+    url_host = bare_host  # preserves any user-supplied :port
+
+    _LOGGER.info(
+        "Protocol detection: probing %s%s",
+        url_host,
+        f" (user-specified {explicit_protocol})" if explicit_protocol else "",
+    )
+
+    http_open = False
+    if explicit_protocol in (None, "http"):
+        http_open = _tcp_probe(hostname, http_port, timeout, address_family=address_family)
+
+    https_open = False
+    if explicit_protocol in (None, "https") and _tcp_probe(
+        hostname, https_port, timeout, address_family=address_family
+    ):
+        https_open = _tls_handshake(hostname, https_port, timeout)
+
+    if https_open:
+        url = f"https://{url_host}"
+        _LOGGER.info("Protocol detection: HTTPS reachable — using %s", url)
+        return ProtocolDetectionResult(
+            success=True,
+            protocol="https",
+            working_url=url,
+        )
+    if http_open:
+        url = f"http://{url_host}"
+        _LOGGER.info("Protocol detection: HTTP reachable — using %s", url)
+        return ProtocolDetectionResult(
+            success=True,
+            protocol="http",
+            working_url=url,
+        )
+
+    tried = (
+        f"TCP {hostname}:{http_port}"
+        if explicit_protocol == "http"
+        else (
+            f"TCP {hostname}:{https_port} (TLS handshake)"
+            if explicit_protocol == "https"
+            else f"TCP {hostname}:{http_port} and {hostname}:{https_port}"
+        )
+    )
+    return ProtocolDetectionResult(
+        success=False,
+        error=f"Cannot connect to {url_host}. Tried: {tried}.",
+    )
 
 
 def check_device_connectivity(target: str, timeout: int = 5) -> tuple[bool, str, str | None]:
     """Check if target is reachable.
 
-    Requires a URL with an explicit scheme (http:// or https://).
+    Accepts a URL with an explicit scheme (``http://``/``https://``) or a
+    bare hostname/IP. When the scheme is omitted, runs :func:`detect_protocol`
+    to choose between HTTP and HTTPS by probing TCP :80 and :443 — preferring
+    HTTPS when its TLS handshake completes. This closes the contributor trap
+    where guessing HTTP misses an HTTPS-only auth challenge.
 
     Args:
-        target: URL with scheme (e.g., "http://192.168.1.1", "https://example.com")
-        timeout: Connection timeout in seconds
+        target: URL with scheme, bare hostname/IP, or ``host:port``.
+        timeout: Connection timeout in seconds.
 
     Returns:
         Tuple of (reachable, scheme, error_message)
         - reachable: True if target responded
-        - scheme: "http" or "https"
+        - scheme: "http" or "https" (empty string when unreachable and unknown)
         - error_message: None if reachable, otherwise describes the problem
     """
-    # Parse target to extract hostname and scheme
     host, provided_scheme = _parse_target(target)
 
     if provided_scheme not in ("http", "https"):
-        return (
-            False,
-            "",
-            f"Missing scheme for '{target}'. Use http:// or https:// (e.g., http://{target})",
-        )
+        # No scheme — auto-detect via TCP/TLS probes.
+        detection = detect_protocol(target, timeout=float(timeout))
+        if not detection.success:
+            return False, "", detection.error
+        scheme = detection.protocol or ""
+        # detect_protocol guarantees working_url is set when success=True.
+        # Fall through to the HTTP-level reachability confirmation so
+        # callers continue to see HTTPError-as-reachable behavior.
+        working_url = detection.working_url or ""
+        host = working_url.removeprefix("https://").removeprefix("http://")
+    else:
+        scheme = provided_scheme
 
-    scheme = provided_scheme
     url = f"{scheme}://{host}/"
     try:
         _urlopen_with_ssl(url, timeout=timeout)

--- a/src/har_capture/cli/capture.py
+++ b/src/har_capture/cli/capture.py
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
 def capture(
     target: Annotated[
         str,
-        typer.Argument(help="URL to capture (must include http:// or https://)"),
+        typer.Argument(
+            help="URL or bare hostname/IP to capture. Scheme auto-detected when omitted.",
+        ),
     ],
     output: Annotated[
         Path | None,
@@ -85,7 +87,7 @@ def capture(
     Use --include-fonts, --include-images, or --include-media to keep them.
 
     Args:
-        target: URL to capture (must include http:// or https://)
+        target: URL or bare hostname/IP to capture (scheme auto-detected via TCP/TLS probes when omitted)
         output: Output HAR filename (auto-generated if not provided)
         browser: Browser engine to use (chromium, firefox, webkit)
         username: Username for HTTP Basic Auth if required
@@ -102,6 +104,7 @@ def capture(
 
     Example:
         har-capture https://example.com
+        har-capture 192.168.100.1                # auto-detect HTTP vs HTTPS
         har-capture http://192.168.100.1 --output capture.har
         har-capture get http://router.local --include-images
     """

--- a/tests/test_capture/test_connectivity.py
+++ b/tests/test_capture/test_connectivity.py
@@ -10,11 +10,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from har_capture.capture.connectivity import (
+    ProtocolDetectionResult,
     _parse_target,
     check_basic_auth,
     check_device_connectivity,
     check_session_contamination,
+    detect_protocol,
 )
+
+_MODULE = "har_capture.capture.connectivity"
 
 # =============================================================================
 # Test Data Tables
@@ -71,22 +75,60 @@ class TestCheckDeviceConnectivity:
         assert error is None
         assert mock_urlopen.call_count == 1
 
-    def test_missing_scheme_returns_error(self) -> None:
-        """Test bare hostname/IP without scheme returns error."""
-        reachable, _scheme, error = check_device_connectivity("192.168.1.1")
+    @patch(f"{_MODULE}.detect_protocol")
+    @patch("urllib.request.urlopen")
+    def test_bare_ip_auto_detects_protocol(
+        self,
+        mock_urlopen: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """Bare IP without scheme triggers detect_protocol() and uses its result."""
+        mock_detect.return_value = ProtocolDetectionResult(
+            success=True,
+            protocol="https",
+            working_url="https://192.168.1.1",
+        )
+        mock_urlopen.return_value = MagicMock()
 
-        assert reachable is False
-        assert error is not None
-        assert "http://" in error
-        assert "https://" in error
+        reachable, scheme, error = check_device_connectivity("192.168.1.1")
 
-    def test_missing_scheme_hostname(self) -> None:
-        """Test bare hostname without scheme returns error."""
+        assert reachable is True
+        assert scheme == "https"
+        assert error is None
+        mock_detect.assert_called_once()
+
+    @patch(f"{_MODULE}.detect_protocol")
+    def test_bare_hostname_unreachable_returns_detection_error(
+        self,
+        mock_detect: MagicMock,
+    ) -> None:
+        """When detect_protocol fails on a bare host, its error surfaces."""
+        mock_detect.return_value = ProtocolDetectionResult(
+            success=False,
+            error="Cannot connect to example.com. Tried: TCP example.com:80 and example.com:443.",
+        )
+
         reachable, _scheme, error = check_device_connectivity("example.com")
 
         assert reachable is False
         assert error is not None
-        assert "Missing scheme" in error
+        assert "Cannot connect to example.com" in error
+
+    @patch(f"{_MODULE}.detect_protocol")
+    @patch("urllib.request.urlopen")
+    def test_explicit_scheme_skips_detect_protocol(
+        self,
+        mock_urlopen: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """An explicit scheme bypasses auto-detection — the user has chosen."""
+        mock_urlopen.return_value = MagicMock()
+
+        reachable, scheme, _error = check_device_connectivity("http://192.168.1.1")
+
+        assert reachable is True
+        assert scheme == "http"
+        mock_detect.assert_not_called()
 
     @pytest.mark.parametrize(
         ("status_code", "reason", "desc"),
@@ -296,13 +338,12 @@ class TestCheckBasicAuth:
 
 
 class TestParseTargetEdgeCases:
-    """Additional edge case tests for _parse_target."""
+    """Edge cases for _parse_target — exercises the wrapper over _strip_protocol.
 
-    def test_ftp_scheme_preserved(self) -> None:
-        """Test non-http schemes are preserved."""
-        host, scheme = _parse_target("ftp://files.example.com")
-        assert host == "files.example.com"
-        assert scheme == "ftp"
+    Note: ftp:// and other non-http schemes are no longer recognized — har-capture
+    only handles http/https targets, so non-http schemes are returned with
+    scheme=None (the input is treated as a bare host string). See _strip_protocol.
+    """
 
     def test_empty_path(self) -> None:
         """Test URL with empty path."""
@@ -502,3 +543,358 @@ class TestCheckSessionContamination:
 
         assert contaminated is False
         assert message is None
+
+
+# =============================================================================
+# detect_protocol() — table-driven scenario bench
+# =============================================================================
+#
+# Adapted from cable_modem_monitor_core/tests/test_connectivity.py with the
+# legacy-TLS classification dropped — har-capture can't act on it (Chromium
+# runs its own TLS stack), so the probe just reports whether HTTPS is usable.
+# The SECLEVEL=0 cipher tolerance in `_tls_handshake` is what's load-bearing
+# (it lets the handshake complete against legacy modems instead of falsely
+# falling back to HTTP) and is exercised by `TestTlsHandshake` directly.
+#
+# Each row drives one full detect_protocol() invocation. ``tls_outcome`` is
+# None when the TLS handshake is not expected to run (either :443 was
+# closed or the user pinned http://…). When set, it's the bool that
+# ``_tls_handshake`` returns.
+
+_DetectCase = tuple[
+    str,  # description
+    str,  # input host
+    bool,  # :80 open?
+    bool,  # :443 open?
+    bool | None,  # _tls_handshake mock return; None if not called
+    bool,  # expected success
+    str | None,  # expected protocol
+    str | None,  # expected working_url ("…" or None)
+    list[int],  # expected ports passed to _tcp_probe
+]
+
+# fmt: off
+DETECT_PROTOCOL_CASES: list[_DetectCase] = [
+    ("http_only",
+     "192.168.100.1",  True,  False, None,
+     True,  "http",  "http://192.168.100.1",  [80, 443]),
+    ("https_handshake_completes_https_wins",
+     "192.168.100.1",  True,  True,  True,
+     True,  "https", "https://192.168.100.1", [80, 443]),
+    ("https_handshake_fails_falls_back_to_http",
+     "192.168.100.1",  True,  True,  False,
+     True,  "http",  "http://192.168.100.1",  [80, 443]),
+    ("https_only",
+     "192.168.100.1",  False, True,  True,
+     True,  "https", "https://192.168.100.1", [80, 443]),
+    ("https_open_but_handshake_fails_no_http",
+     "192.168.100.1",  False, True,  False,
+     False, None,    None,                     [80, 443]),
+    ("both_ports_closed",
+     "192.168.100.1",  False, False, None,
+     False, None,    None,                     [80, 443]),
+    ("explicit_http_skips_tls_probe",
+     "http://192.168.100.1", True, True, None,
+     True,  "http",  "http://192.168.100.1",  [80]),
+    ("explicit_https_skips_http_probe",
+     "https://192.168.100.1", True, True, True,
+     True,  "https", "https://192.168.100.1", [443]),
+    ("explicit_http_with_port_probes_only_that_port",
+     "http://127.0.0.1:36771", True, False, None,
+     True,  "http",  "http://127.0.0.1:36771", [36771]),
+    ("explicit_https_with_port_probes_only_that_port",
+     "https://127.0.0.1:8443", False, True, True,
+     True,  "https", "https://127.0.0.1:8443", [8443]),
+    ("ipv6_bracketed_https_handshake_completes",
+     "[::1]:8443", False, True, True,
+     True,  "https", "https://[::1]:8443", [8443, 8443]),
+    ("ipv6_bracketed_http_only",
+     "[::1]", True, False, None,
+     True,  "http", "http://[::1]", [80, 443]),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "description, host, port_80_open, port_443_open, tls_outcome, "
+    "expected_success, expected_protocol, expected_working_url, expected_tcp_ports",
+    DETECT_PROTOCOL_CASES,
+    ids=[c[0] for c in DETECT_PROTOCOL_CASES],
+)
+class TestDetectProtocol:
+    """Protocol detection — one row per scenario in DETECT_PROTOCOL_CASES."""
+
+    def test_detection_outcome(
+        self,
+        description: str,
+        host: str,
+        port_80_open: bool,
+        port_443_open: bool,
+        tls_outcome: bool | None,
+        expected_success: bool,
+        expected_protocol: str | None,
+        expected_working_url: str | None,
+        expected_tcp_ports: list[int],
+    ) -> None:
+        """One detect_protocol() invocation per row.
+
+        Bracketed-IPv6 inputs additionally assert the address family
+        passed to ``_tcp_probe`` is ``AF_INET6`` (capture-everything
+        philosophy: don't silently false-fail v6-only targets).
+        """
+        import socket as _socket
+
+        tcp_calls: list[int] = []
+        tcp_families: list[int] = []
+
+        def tcp_side_effect(
+            host: str,
+            port: int,
+            timeout: float,
+            *,
+            address_family: int = _socket.AF_INET,
+        ) -> bool:
+            tcp_calls.append(port)
+            tcp_families.append(address_family)
+            # When user provides a custom port, both http_port and https_port
+            # collapse to it. The row's port_80_open / port_443_open booleans
+            # then map by *intent*: for an http://-prefixed input, port_80_open
+            # governs the user port; for an https://-prefixed input,
+            # port_443_open governs it. detect_protocol only probes one port
+            # in the explicit-prefix case, so this disambiguates cleanly.
+            if port == 80:
+                return port_80_open
+            if port == 443:
+                return port_443_open
+            return port_443_open or port_80_open
+
+        tls_patch = (
+            patch(f"{_MODULE}._tls_handshake", return_value=tls_outcome)
+            if tls_outcome is not None
+            else patch(f"{_MODULE}._tls_handshake")
+        )
+        with (
+            patch(f"{_MODULE}._tcp_probe", side_effect=tcp_side_effect),
+            tls_patch as tls,
+        ):
+            result = detect_protocol(host)
+
+        assert result.success is expected_success, description
+        assert result.protocol == expected_protocol, description
+        if expected_working_url is None:
+            assert result.working_url is None, description
+            assert result.error is not None, description
+        else:
+            assert result.working_url == expected_working_url, description
+
+        assert tcp_calls == expected_tcp_ports, description
+
+        # Bracketed IPv6 inputs must select AF_INET6 across every probe;
+        # everything else must stay on AF_INET.
+        expected_family = _socket.AF_INET6 if "[" in host else _socket.AF_INET
+        assert all(f == expected_family for f in tcp_families), (
+            f"{description}: expected family {expected_family}, got {tcp_families}"
+        )
+
+        if tls_outcome is None:
+            tls.assert_not_called()
+        else:
+            tls.assert_called_once()
+
+
+# =============================================================================
+# _strip_protocol() — pure helper, exhaustive table
+# =============================================================================
+
+# fmt: off
+_STRIP_PROTOCOL_CASES = [
+    ("bare_ip",                   "192.168.100.1",            (None,    "192.168.100.1")),
+    ("bare_hostname",             "modem.local",              (None,    "modem.local")),
+    ("http_prefix",               "http://192.168.100.1",     ("http",  "192.168.100.1")),
+    ("https_prefix",              "https://192.168.100.1",    ("https", "192.168.100.1")),
+    ("http_with_path",            "http://192.168.100.1/x",   ("http",  "192.168.100.1")),
+    ("https_with_path_and_query", "https://m.local/a?b=1",    ("https", "m.local")),
+    ("bare_ip_with_path",         "192.168.100.1/login",      (None,    "192.168.100.1")),
+    ("http_with_port",            "http://192.168.100.1:8080", ("http", "192.168.100.1:8080")),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "description, host, expected",
+    _STRIP_PROTOCOL_CASES,
+    ids=[c[0] for c in _STRIP_PROTOCOL_CASES],
+)
+def test_strip_protocol(description: str, host: str, expected: tuple[str | None, str]) -> None:
+    """_strip_protocol returns (protocol, bare_host_with_optional_port)."""
+    from har_capture.capture.connectivity import _strip_protocol
+
+    assert _strip_protocol(host) == expected, description
+
+
+# =============================================================================
+# _split_host_port() — pure helper, exhaustive table
+# =============================================================================
+
+# fmt: off
+_SPLIT_HOST_PORT_CASES = [
+    ("ipv4_no_port",             "192.168.100.1",        ("192.168.100.1", None)),
+    ("ipv4_with_port",           "192.168.100.1:8080",   ("192.168.100.1", 8080)),
+    ("hostname_no_port",         "modem.local",          ("modem.local",   None)),
+    ("hostname_with_port",       "modem.local:8443",     ("modem.local",   8443)),
+    ("loopback_with_high_port",  "127.0.0.1:36771",      ("127.0.0.1",     36771)),
+    ("ipv6_bracketed_no_port",   "[::1]",                ("::1",           None)),
+    ("ipv6_bracketed_with_port", "[::1]:8080",           ("::1",           8080)),
+    ("ipv6_bracketed_partial",   "[::1",                 ("[::1",          None)),
+    ("trailing_colon_no_port",   "host:",                ("host:",         None)),
+]
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "description, host, expected",
+    _SPLIT_HOST_PORT_CASES,
+    ids=[c[0] for c in _SPLIT_HOST_PORT_CASES],
+)
+def test_split_host_port(description: str, host: str, expected: tuple[str, int | None]) -> None:
+    """_split_host_port returns (hostname, port|None) preserving IPv6 bracket form."""
+    from har_capture.capture.connectivity import _split_host_port
+
+    assert _split_host_port(host) == expected, description
+
+
+class TestTcpProbe:
+    """Direct tests for _tcp_probe — IPv4 pinning and resolution failure."""
+
+    @patch(f"{_MODULE}.socket.getaddrinfo")
+    def test_resolution_failure_returns_false(self, mock_gai: MagicMock) -> None:
+        from har_capture.capture.connectivity import _tcp_probe
+
+        mock_gai.side_effect = OSError("name not known")
+        assert _tcp_probe("nope.invalid", 80, timeout=1.0) is False
+
+    @patch(f"{_MODULE}.socket.socket")
+    @patch(f"{_MODULE}.socket.getaddrinfo")
+    def test_defaults_to_ipv4(self, mock_gai: MagicMock, mock_socket: MagicMock) -> None:
+        """Default ``getaddrinfo`` family is AF_INET.
+
+        Protects against dual-stack false-fail on IPv4-only LAN devices.
+        """
+        import socket as _socket
+
+        from har_capture.capture.connectivity import _tcp_probe
+
+        mock_gai.return_value = [
+            (_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("192.168.100.1", 80)),
+        ]
+        mock_socket.return_value.connect.return_value = None
+
+        _tcp_probe("192.168.100.1", 80, timeout=1.0)
+
+        mock_gai.assert_called_once()
+        call_kwargs = mock_gai.call_args.kwargs
+        assert call_kwargs.get("family") == _socket.AF_INET
+
+    @patch(f"{_MODULE}.socket.socket")
+    @patch(f"{_MODULE}.socket.getaddrinfo")
+    def test_passes_ipv6_family_when_requested(
+        self,
+        mock_gai: MagicMock,
+        mock_socket: MagicMock,
+    ) -> None:
+        """``address_family=AF_INET6`` propagates through to ``getaddrinfo``.
+
+        Bracketed IPv6 targets must reach the v6 resolver — the IPv4 default
+        would silently false-fail and drop captures of v6-only devices.
+        """
+        import socket as _socket
+
+        from har_capture.capture.connectivity import _tcp_probe
+
+        mock_gai.return_value = [
+            (_socket.AF_INET6, _socket.SOCK_STREAM, 0, "", ("::1", 8443, 0, 0)),
+        ]
+        mock_socket.return_value.connect.return_value = None
+
+        _tcp_probe("::1", 8443, timeout=1.0, address_family=_socket.AF_INET6)
+
+        mock_gai.assert_called_once()
+        assert mock_gai.call_args.kwargs.get("family") == _socket.AF_INET6
+
+    @patch(f"{_MODULE}.socket.socket")
+    @patch(f"{_MODULE}.socket.getaddrinfo")
+    def test_connect_failure_returns_false(
+        self,
+        mock_gai: MagicMock,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Connect-time OSError on a resolved address returns False (closed port)."""
+        import socket as _socket
+
+        from har_capture.capture.connectivity import _tcp_probe
+
+        mock_gai.return_value = [
+            (_socket.AF_INET, _socket.SOCK_STREAM, 0, "", ("192.168.100.1", 80)),
+        ]
+        mock_socket.return_value.connect.side_effect = OSError("connection refused")
+
+        assert _tcp_probe("192.168.100.1", 80, timeout=1.0) is False
+        mock_socket.return_value.close.assert_called_once()
+
+
+class TestTlsHandshake:
+    """Direct tests for _tls_handshake — completes against any TLS version."""
+
+    @pytest.mark.parametrize(
+        "negotiated_version",
+        ["TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"],
+    )
+    @patch(f"{_MODULE}.socket.create_connection")
+    @patch(f"{_MODULE}.ssl.SSLContext")
+    def test_completes_for_all_tls_versions(
+        self,
+        mock_context_cls: MagicMock,
+        mock_create_conn: MagicMock,
+        negotiated_version: str,
+    ) -> None:
+        """SECLEVEL=0 cipher tolerance completes the handshake on any TLS version.
+
+        Legacy devices (TLS 1.0/1.1, SSLv3) must succeed here — without that
+        tolerance we'd false-fail HTTPS and capture HTTP instead, the inverse
+        CM1200 trap.
+        """
+        from har_capture.capture.connectivity import _tls_handshake
+
+        raw_sock = MagicMock()
+        mock_create_conn.return_value.__enter__.return_value = raw_sock
+
+        tls_sock = MagicMock()
+        tls_sock.version.return_value = negotiated_version
+        ctx = mock_context_cls.return_value
+        ctx.wrap_socket.return_value.__enter__.return_value = tls_sock
+
+        assert _tls_handshake("192.168.100.1", 443, timeout=2.0) is True
+
+    @patch(f"{_MODULE}.socket.create_connection")
+    def test_handshake_failure_returns_false(
+        self,
+        mock_create_conn: MagicMock,
+    ) -> None:
+        import ssl as _ssl
+
+        from har_capture.capture.connectivity import _tls_handshake
+
+        mock_create_conn.side_effect = _ssl.SSLError("handshake failure")
+
+        assert _tls_handshake("192.168.100.1", 443, timeout=2.0) is False
+
+
+class TestProtocolDetectionResult:
+    """ProtocolDetectionResult dataclass."""
+
+    def test_defaults(self) -> None:
+        """Default values for a failed result."""
+        result = ProtocolDetectionResult(success=False)
+        assert result.protocol is None
+        assert result.working_url is None
+        assert result.error is None


### PR DESCRIPTION
## Summary

- Bare hostnames/IPs auto-detect HTTP vs HTTPS via stdlib TCP+TLS probes; explicit schemes still bypass detection. Closes the CM1200-class trap where guessing `http://` silently misses an HTTPS-only auth challenge.
- Probe handshake uses `SECLEVEL=0` cipher tolerance so legacy TLS 1.0/1.1 devices succeed (capture-everything over false-fail). `legacy_ssl` flag deliberately not surfaced — Chromium runs its own TLS stack and har-capture cannot act on the classification (see ADR-10).
- Bracketed IPv6 input (`[::1]:8443`) auto-selects `AF_INET6`; unbracketed inputs keep the IPv4 default to protect against dual-stack false-fails on consumer LAN devices.
- DRY cleanup: `_parse_target` is now a thin wrapper over `_strip_protocol`. Scheme matching made case-insensitive (`HTTPS://...` recognized).
- Specs (`CAPTURE_SPEC`, `CLI_REFERENCE`, `USE_CASES`) and `ARCHITECTURE_DECISIONS` (new ADR-10, ADR-2 forward-pointer) updated in the same change. `connectivity.py` at 100% coverage.

## Test plan

- [x] Unit: 1885 non-integration tests pass (`pytest -m "not integration"`)
- [x] `connectivity.py` at 100% (155 stmts, 46 branches)
- [x] All pre-commit hooks green (ruff, ruff-format, mypy, commitizen, mdformat, detect-secrets)
- [ ] Manual: `har-capture 192.168.100.1` against an HTTPS-only modem confirms HTTPS auto-pick + auth challenge captured
- [ ] Manual: `har-capture HTTPS://example.com` (uppercase scheme) honored as explicit
- [ ] Manual: `har-capture [::1]:8443` against a v6 loopback target probes IPv6
- [ ] Manual: `har-capture http://192.168.100.1` (explicit) bypasses detection — no extra TCP/TLS probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)