### PR TITLE
fix(tests): widen timing budget on stays_pending / never_quiet fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Test-fixture timing flake (`stays_pending` / `never_quiet`)** — `tests/fixtures/test_browser.json` had `timeout_s: 0.05` for the two timing-loop test cases that assert `evaluate.call_count >= 2`. The 50ms budget passed in CI's clean Linux container but flaked under local CPU pressure (e.g., when `release.py` runs the full 1970-test suite back-to-back), failing with `assert 1 >= 2` because the loop only iterated once. Surfaced — and shipped through — during the v0.8.1 release. Bumping to `timeout_s: 0.5` gives 10× headroom; verified across three concurrent stress runs.
+
 ## [0.8.1] - 2026-05-03
 
 ### Fixed

--- a/tests/fixtures/test_browser.json
+++ b/tests/fixtures/test_browser.json
@@ -49,13 +49,13 @@
   "wait_for_pending_data_cases": [
     {"id": "immediate_zero",       "pending_values": [0],           "timeout_s": 1.0, "expect_timeout": false, "description": "returns immediately when pending is 0"},
     {"id": "drains_to_zero",       "pending_values": [3, 2, 1, 0], "timeout_s": 1.0, "expect_timeout": false, "description": "waits until pending drains to 0"},
-    {"id": "stays_pending",        "pending_values": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "timeout_s": 0.05, "expect_timeout": true, "description": "times out when requests never complete"},
+    {"id": "stays_pending",        "pending_values": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "timeout_s": 0.5,  "expect_timeout": true, "description": "times out when requests never complete (timeout_s=0.5 not 0.05: tighter values flake under local CPU pressure when 1969 other tests compete; CI's clean container hid this for releases)"},
     {"id": "evaluate_exception",   "pending_values": "exception",  "timeout_s": 1.0, "expect_timeout": false, "description": "returns on page.evaluate exception"}
   ],
   "wait_for_quiescence_cases": [
     {"id": "already_quiet",      "pending_values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "returns when already quiescent"},
     {"id": "activity_then_quiet", "pending_values": [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "waits through activity then detects quiescence"},
-    {"id": "never_quiet",        "pending_values": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], "quiescence_s": 5.0,  "timeout_s": 0.05, "expect_timeout": true, "description": "times out when activity oscillates"},
+    {"id": "never_quiet",        "pending_values": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], "quiescence_s": 5.0,  "timeout_s": 0.5,  "expect_timeout": true, "description": "times out when activity oscillates (timeout_s=0.5 not 0.05; same flake mode as stays_pending)"},
     {"id": "evaluate_exception", "pending_values": "exception",    "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "returns on page.evaluate exception"}
   ],
   "output_path_cases": [


### PR DESCRIPTION
## Summary

- `tests/fixtures/test_browser.json` had `timeout_s: 0.05` for the two timing-loop cases that assert `evaluate.call_count >= 2`. The 50ms budget passes in CI's clean Linux container but flakes locally under CPU pressure (a single iteration consumes the whole budget on a busy interpreter), failing with `assert 1 >= 2`.
- Surfaced — and shipped past — during the v0.8.1 release. `release.py` runs the full 1970-test suite locally; the matrix CI's per-job isolation kept it invisible for prior releases. Bumping to `timeout_s: 0.5` gives 10× headroom.
- This PR exists because I framed the failure as "pre-existing" during v0.8.1 and shipped through it. That's the same deferred-fix pattern the v0.8.1 changelog explicitly called out for the per-module coverage rot. Filed it after the fact rather than during the release; better late than later.

## Test plan

- [x] Reproduced the failure locally: `pytest -v --no-cov` with full 1970-test load → `assert 1 >= 2` on `stays_pending`
- [x] Applied fix → full suite green: `1970 passed in 107.31s`
- [x] Three concurrent stress runs of `TestWaitForPendingData` + `TestWaitForNetworkQuiescence` → all green
- [x] `scripts/ci-local.sh` (matrix profile, isolated `.venv-ci/`) passes
- [x] Per-module coverage floors satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)