### PR TITLE
chore(release): v0.8.2 — timing-flake fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-03
+
 ### Fixed
 
-- **Test-fixture timing flake (`stays_pending` / `never_quiet`)** — `tests/fixtures/test_browser.json` had `timeout_s: 0.05` for the two timing-loop test cases that assert `evaluate.call_count >= 2`. The 50ms budget passed in CI's clean Linux container but flaked under local CPU pressure (e.g., when `release.py` runs the full 1970-test suite back-to-back), failing with `assert 1 >= 2` because the loop only iterated once. Surfaced — and shipped through — during the v0.8.1 release. Bumping to `timeout_s: 0.5` gives 10× headroom; verified across three concurrent stress runs.
+- **Test-fixture timing flake (`stays_pending` / `never_quiet`)** — `tests/fixtures/test_browser.json` had `timeout_s: 0.05` for the two timing-loop test cases that assert `evaluate.call_count >= 2`. The 50ms budget passed in CI's clean Linux container but flaked under local CPU pressure (e.g., when `release.py` runs the full 1970-test suite back-to-back), failing with `assert 1 >= 2` because the loop only iterated once. Surfaced — and shipped through — during the v0.8.1 release; framed as "pre-existing" at the time, which is exactly the deferred-fix pattern v0.8.1's own changelog called out for the per-module coverage rot. Bumping to `timeout_s: 0.5` gives 10× headroom; verified across three concurrent stress runs.
 
 ## [0.8.1] - 2026-05-03
 
@@ -527,4 +529,5 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.7.1]: https://github.com/solentlabs/har-capture/compare/v0.7.0...v0.7.1
 [0.8.0]: https://github.com/solentlabs/har-capture/compare/v0.7.1...v0.8.0
 [0.8.1]: https://github.com/solentlabs/har-capture/compare/v0.8.0...v0.8.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.8.1...HEAD
+[0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.8.2...HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.8.1"
+version = "0.8.2"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (


### PR DESCRIPTION
## Summary

- Bumps version `0.8.1` → `0.8.2` in `pyproject.toml` and `__init__.py`.
- Finalizes the `CHANGELOG.md` section — moves the timing-flake fix entry from `[Unreleased]` to `[0.8.2] - 2026-05-03` and adds the comparison link.

## Why a v0.8.2 patch instead of bundling into the next release

The fix landed on main in PR #43 as `[Unreleased]`. I initially proposed deferring the release until other work accumulated — that's exactly the deferred-fix pattern v0.8.1's own changelog called out for the per-module coverage rot. The fix surfaced during the v0.8.1 release flow and shipped past it; cutting v0.8.2 immediately ships it cleanly and keeps the journal-entry rule honest.

## Test plan

- [x] `scripts/ci-local.sh` passes (matrix profile, isolated `.venv-ci/`, 1952 tests, all coverage floors)
- [x] Versions consistent: `pyproject.toml` 0.8.2, `__init__.py` 0.8.2, CHANGELOG `[0.8.2]` section + comparison link
- [x] Pre-commit hooks green (ruff, ruff-format, mypy, commitizen, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)