### PR TITLE
feat(capture): surface browser dialogs for user-driven capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Interactive JavaScript dialogs now surface in headed captures** — For interactive browser sessions (`headless=False`, `timeout=None`), native `alert` / `confirm` / `prompt` dialogs are allowed to appear in the Playwright window instead of being silently auto-dismissed immediately. The resulting HAR now records `_solentlabs.dialogs` entries with the dialog type, message, default value, inferred action (`accept` or `dismiss`), and `resolved_by="browser_ui"`. This follows the same audit-trail shape as `_solentlabs.popups`, and we also tightened the surrounding docs by updating `ARCHITECTURE.md` to describe both popup and dialog metadata surfaces rather than leaving popup behavior implicit.
+
 ## [0.8.3] - 2026-05-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Chrome DevTools now sanitizes cookies and auth headers, but HAR files contain **
 - **Zero dependencies** - Core sanitization uses only Python stdlib
 - **Format-preserving hashes** - Track the same device across requests without exposing real values
 - **One-command workflow** - Capture, sanitize, and compress in a single step
+- **Interactive browser flows preserved** - Handle browser auth, popups, and dialogs while still recording the resulting traffic
 
 [See detailed comparison with all tools →](docs/COMPARISON.md)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,7 +120,7 @@ The core Playwright session. Key design decisions:
 
 **Wait-for-data**: An init script monkey-patches `XMLHttpRequest.send` and `window.fetch` to track in-flight requests via `window.__harCapturePendingRequests`. After each navigation, the system polls this counter until 2 seconds of network silence (vs Playwright's 500ms `networkidle`). A `framenavigated` event listener ensures async data completes before page transitions. Disabled in `--minimal` mode for devices with persistent connections.
 
-**State capture**: After navigation, cookies (`context.cookies()`), localStorage (`context.storage_state()`), and sessionStorage (JS evaluation) are captured and injected into the HAR as `_har_capture` metadata.
+**State capture**: After navigation, cookies (`context.cookies()`), localStorage (`context.storage_state()`), and sessionStorage (JS evaluation) are captured and injected into the HAR as `_har_capture` metadata. Context-level browser events that matter for downstream analysis are also surfaced under `_solentlabs`: `pre_capture_cookies` for clean-session auditing, `popups` when the device opens a new page, and interactive JavaScript `dialogs` when a headed user-driven capture resolves a native `alert` / `confirm` / `prompt` in the browser UI.
 
 **Error recovery**: Missing browser executables and system dependencies are detected by pattern matching, fixed automatically (reinstall), and retried once.
 
@@ -128,7 +128,7 @@ See [Capture Spec](specs/CAPTURE_SPEC.md) for full details (context config, wait
 
 ### Post-Capture Processing
 
-After the browser closes: metadata injection (probes, cookies, storage, tool version, `_solentlabs.pre_capture_cookies` audit) → sanitization (Pass 1) → interactive review (Pass 2) → bloat filtering + deduplication → gzip compression → temp file cleanup.
+After the browser closes: metadata injection (probes, cookies, storage, tool version, `_solentlabs.pre_capture_cookies`, `_solentlabs.popups`, `_solentlabs.dialogs`) → sanitization (Pass 1) → interactive review (Pass 2) → bloat filtering + deduplication → gzip compression → temp file cleanup.
 
 The raw temp file is **always** deleted, ensuring PII doesn't persist on disk. See [Capture Spec](specs/CAPTURE_SPEC.md#post-capture-processing) for the full processing pipeline and file cleanup rules.
 

--- a/docs/specs/CAPTURE_SPEC.md
+++ b/docs/specs/CAPTURE_SPEC.md
@@ -161,6 +161,14 @@ Controls the `wait_until` argument to Playwright's `page.goto()`. Accepts any Pl
 
 ## Browser Capture Detail
 
+### Browser event auditing
+
+`browser.py` records two browser-event audit trails under `log._solentlabs` so downstream tools can tell that a secondary browser interaction happened even when the underlying HAR entries are interleaved with normal page traffic.
+
+**`_solentlabs.popups`** records popup pages opened after the initial page (`window.open`, `target="_blank"`, or equivalent new-page events). Each entry stores the popup's initial URL and an `opened_at` timestamp. The popup's actual request/response traffic is already captured by the context-level HAR recorder; this list exists to make the popup event itself visible to downstream analysis.
+
+**`_solentlabs.dialogs`** records interactive JavaScript dialogs (`alert`, `confirm`, `prompt`) for headed, user-driven captures only (`headless=False`, `timeout=None`). `browser.py` injects a small wrapper around those APIs so that once the user answers the native browser dialog in the browser UI, the capture records the dialog type, message, default value, an `opened_at` timestamp, inferred action (`accept` or `dismiss`), and `resolved_by="browser_ui"`. This preserves the tool's observability stance: surface what the user did, do not auto-accept on their behalf. Headless or timed captures keep Playwright's default auto-dismiss behavior to avoid hanging unattended runs.
+
 ### Internal Decomposition
 
 `capture_device_har()` is the public API — its signature is unchanged. Internally, it delegates to five extracted functions that can each be tested independently:
@@ -191,7 +199,7 @@ Testable with: one mock (`sync_playwright`).
 
 #### `_inject_har_metadata(temp_path, target_url, probes, session)`
 
-Reads the raw HAR from the temp file, injects `_probes`, `_har_capture` (cookies, storage), and `_solentlabs` (pre-capture cookies), writes back. Handles corrupt/unreadable HAR gracefully.
+Reads the raw HAR from the temp file, injects `_probes`, `_har_capture` (cookies, storage), and `_solentlabs` (pre-capture cookies, popup audit trail, dialog audit trail), writes back. Handles corrupt/unreadable HAR gracefully.
 
 Testable with: zero mocks (real temp file).
 
@@ -297,13 +305,7 @@ Immediately after context creation and before any navigation, `context.cookies()
 With the clean `storage_state`, this list should always be empty. A non-empty list indicates the context inherited cookies despite the explicit clean state — a signal for downstream tools that the capture may be contaminated.
 
 ```json
-{
-  "log": {
-    "_solentlabs": {
-      "pre_capture_cookies": []
-    }
-  }
-}
+{"log": {"_solentlabs": {"pre_capture_cookies": []}}}
 ```
 
 ### Wait-for-Data Mechanism
@@ -513,6 +515,8 @@ har_data["log"]["_har_capture"] = {
 }
 har_data["log"]["_solentlabs"] = {
     "pre_capture_cookies": pre_capture_cookies,  # Cookie jar state before navigation
+    "popups": popup_records,                     # Popup audit trail
+    "dialogs": dialog_records,                   # Dialog audit trail
 }
 ```
 
@@ -581,4 +585,4 @@ class CaptureOptions:
 1. **Service workers are always blocked** — This is hardcoded in context config, not configurable, to ensure fresh captures.
 1. **Self-signed certs are always accepted** — Both probes and Playwright context ignore certificate errors.
 1. **Browser context is always clean** — `storage_state={"cookies": [], "origins": []}` is hardcoded. No cookies, localStorage, or credentials leak from previous sessions.
-1. **Pre-capture cookie state is always recorded** — `_solentlabs.pre_capture_cookies` is emitted in every capture, even when empty. Downstream tools can verify context cleanliness without assumptions.
+1. **`_solentlabs` audit surfaces are always present** — `_solentlabs.pre_capture_cookies`, `_solentlabs.popups`, and `_solentlabs.dialogs` are emitted in every capture, even when the popup/dialog lists are empty. Downstream tools can verify context cleanliness and see whether secondary browser events occurred without relying on missing-key heuristics.

--- a/src/har_capture/capture/browser.py
+++ b/src/har_capture/capture/browser.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import time
 from collections.abc import Callable
@@ -100,6 +101,44 @@ _WAIT_FOR_DATA_INIT_SCRIPT = """\
 })();
 """
 
+_DIALOG_OBSERVER_INIT_SCRIPT = """\
+(function () {
+    window.__harCaptureDialogOutcomes = window.__harCaptureDialogOutcomes || [];
+
+    var _alert = window.alert;
+    window.alert = function (message) {
+        _alert.call(window, message);
+        window.__harCaptureDialogOutcomes.push({
+            type: "alert",
+            message: String(message),
+            action: "accept"
+        });
+    };
+
+    var _confirm = window.confirm;
+    window.confirm = function (message) {
+        var accepted = _confirm.call(window, message);
+        window.__harCaptureDialogOutcomes.push({
+            type: "confirm",
+            message: String(message),
+            action: accepted ? "accept" : "dismiss"
+        });
+        return accepted;
+    };
+
+    var _prompt = window.prompt;
+    window.prompt = function (message, defaultValue) {
+        var value = _prompt.call(window, message, defaultValue);
+        window.__harCaptureDialogOutcomes.push({
+            type: "prompt",
+            message: String(message),
+            action: value === null ? "dismiss" : "accept"
+        });
+        return value;
+    };
+})();
+"""
+
 
 def _wait_for_pending_data(page: Any, timeout_s: float = _DATA_WAIT_NAV_TIMEOUT_S) -> None:
     """Wait until in-flight JS requests (XHR/fetch) reach zero.
@@ -121,6 +160,25 @@ def _wait_for_pending_data(page: Any, timeout_s: float = _DATA_WAIT_NAV_TIMEOUT_
             return
         page.wait_for_timeout(_DATA_WAIT_POLL_MS)
     _LOGGER.debug("Pending-data wait timed out after %.1fs", timeout_s)
+
+
+def _get_dialog_outcome(page: Any, outcome_index: int) -> dict[str, Any] | None:
+    """Return the recorded dialog outcome for a given dialog index."""
+    try:
+        outcomes = page.evaluate("window.__harCaptureDialogOutcomes || []")
+    except Exception:
+        return None
+
+    if not isinstance(outcomes, list):
+        return None
+    if len(outcomes) <= outcome_index:
+        return None
+
+    outcome = outcomes[outcome_index]
+    if not isinstance(outcome, dict):
+        return None
+
+    return outcome
 
 
 def _wait_for_network_quiescence(
@@ -262,6 +320,11 @@ class BrowserSessionResult:
         captured_bodies: Eagerly captured response bodies keyed by
             ``"<method>|<url>|<status>"`` — used to patch HAR entries
             whose bodies were evicted before Playwright flushed the HAR.
+        dialogs: Browser dialogs observed during interactive capture.
+            For headed, user-driven runs, each entry records the dialog type,
+            message, default value, inferred action (accept/dismiss), and that
+            the dialog was resolved by the browser UI. Headless or timed
+            captures keep Playwright's default auto-dismiss behavior.
         popups: One entry per page opened in the context after the initial
             page (i.e., popups via ``window.open`` / ``target="_blank"`` /
             ``context.new_page``). Each entry records the popup's initial
@@ -279,6 +342,7 @@ class BrowserSessionResult:
     web_storage_local: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     web_storage_session: dict[str, str] = dataclasses.field(default_factory=dict)
     captured_bodies: dict[str, bytes] = dataclasses.field(default_factory=dict)
+    dialogs: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     popups: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     success: bool = True
     error: str | None = None
@@ -527,6 +591,41 @@ def _run_browser_session(
             result.pre_capture_cookies = []
 
         page = context.new_page()
+        interactive_dialog_capture = not headless and timeout is None
+        if interactive_dialog_capture:
+            page.add_init_script(_DIALOG_OBSERVER_INIT_SCRIPT)
+
+            def _on_dialog(dialog: Any) -> None:
+                dialog_index = len(result.dialogs)
+                dialog_info = {
+                    "type": getattr(dialog, "type", None),
+                    "message": getattr(dialog, "message", None),
+                    "default_value": getattr(dialog, "default_value", None),
+                    "opened_at": datetime.now().isoformat(timespec="seconds"),
+                    "action": "unknown",
+                    "resolved_by": "unknown",
+                }
+                sys.stderr.write(f"[har-capture dialog] {dialog_info['type']}: {dialog_info['message']}\n")
+                sys.stderr.flush()
+                try:
+                    while True:
+                        outcome = _get_dialog_outcome(page, dialog_index)
+                        if outcome is not None:
+                            dialog_info["action"] = outcome.get("action", "unknown")
+                            dialog_info["resolved_by"] = "browser_ui"
+                            break
+                        time.sleep(0.1)
+                except Exception as e:
+                    _LOGGER.warning("Failed to handle dialog: %s", e)
+                result.dialogs.append(dialog_info)
+                sys.stderr.write(
+                    "[har-capture dialog] "
+                    f"resolved_by={dialog_info['resolved_by']} action={dialog_info['action']} "
+                    f"{dialog_info['type']}: {dialog_info['message']}\n"
+                )
+                sys.stderr.flush()
+
+            page.on("dialog", _on_dialog)
 
         _is_first_nav = [True]
         _quiescence_disabled = [not wait_for_data]
@@ -786,6 +885,7 @@ def _inject_har_metadata(
         raw_har["log"]["_solentlabs"] = {
             "pre_capture_cookies": session.pre_capture_cookies,
             "popups": session.popups,
+            "dialogs": session.dialogs,
         }
         with open(temp_path, "w", encoding="utf-8") as f:
             json.dump(raw_har, f)

--- a/tests/fixtures/test_browser.json
+++ b/tests/fixtures/test_browser.json
@@ -1,83 +1,276 @@
 {
   "private_ip_cases": [
-    {"ip": "10.0.0.1",         "expected": true,  "id": "10_network_start"},
-    {"ip": "10.0.0.0",         "expected": true,  "id": "10_network_zero"},
-    {"ip": "10.255.255.255",   "expected": true,  "id": "10_network_end"},
-    {"ip": "10.100.50.25",     "expected": true,  "id": "10_network_middle"},
-    {"ip": "172.16.0.1",       "expected": true,  "id": "172_16_start"},
-    {"ip": "172.31.255.255",   "expected": true,  "id": "172_31_end"},
-    {"ip": "172.20.100.50",    "expected": true,  "id": "172_20_middle"},
-    {"ip": "172.15.0.1",       "expected": false, "id": "172_15_not_private"},
-    {"ip": "172.32.0.1",       "expected": false, "id": "172_32_not_private"},
-    {"ip": "192.168.0.1",      "expected": true,  "id": "192_168_0_1"},
-    {"ip": "192.168.1.1",      "expected": true,  "id": "192_168_1_1"},
-    {"ip": "192.168.100.1",    "expected": true,  "id": "192_168_100_1"},
-    {"ip": "192.168.255.255",  "expected": true,  "id": "192_168_end"},
-    {"ip": "127.0.0.1",        "expected": true,  "id": "localhost"},
-    {"ip": "127.0.0.0",        "expected": true,  "id": "loopback_start"},
-    {"ip": "127.255.255.255",  "expected": true,  "id": "loopback_end"},
-    {"ip": "0.0.0.0",          "expected": true,  "id": "all_zeros_redacted"},
-    {"ip": "8.8.8.8",          "expected": false, "id": "google_dns"},
-    {"ip": "8.8.4.4",          "expected": false, "id": "google_dns_secondary"},
-    {"ip": "1.1.1.1",          "expected": false, "id": "cloudflare_dns"},
-    {"ip": "208.67.222.222",   "expected": false, "id": "opendns"},
-    {"ip": "9.9.9.9",          "expected": false, "id": "quad9"},
-    {"ip": "192.0.2.1",        "expected": false, "id": "test_net_1"},
-    {"ip": "203.0.113.1",      "expected": false, "id": "test_net_3"},
-    {"ip": "198.51.100.1",     "expected": false, "id": "test_net_2"},
-    {"ip": "192.167.1.1",      "expected": false, "id": "192_167_not_private"},
-    {"ip": "192.169.1.1",      "expected": false, "id": "192_169_not_private"},
-    {"ip": "11.0.0.1",         "expected": false, "id": "11_not_private"}
+    { "ip": "10.0.0.1", "expected": true, "id": "10_network_start" },
+    { "ip": "10.0.0.0", "expected": true, "id": "10_network_zero" },
+    { "ip": "10.255.255.255", "expected": true, "id": "10_network_end" },
+    { "ip": "10.100.50.25", "expected": true, "id": "10_network_middle" },
+    { "ip": "172.16.0.1", "expected": true, "id": "172_16_start" },
+    { "ip": "172.31.255.255", "expected": true, "id": "172_31_end" },
+    { "ip": "172.20.100.50", "expected": true, "id": "172_20_middle" },
+    { "ip": "172.15.0.1", "expected": false, "id": "172_15_not_private" },
+    { "ip": "172.32.0.1", "expected": false, "id": "172_32_not_private" },
+    { "ip": "192.168.0.1", "expected": true, "id": "192_168_0_1" },
+    { "ip": "192.168.1.1", "expected": true, "id": "192_168_1_1" },
+    { "ip": "192.168.100.1", "expected": true, "id": "192_168_100_1" },
+    { "ip": "192.168.255.255", "expected": true, "id": "192_168_end" },
+    { "ip": "127.0.0.1", "expected": true, "id": "localhost" },
+    { "ip": "127.0.0.0", "expected": true, "id": "loopback_start" },
+    { "ip": "127.255.255.255", "expected": true, "id": "loopback_end" },
+    { "ip": "0.0.0.0", "expected": true, "id": "all_zeros_redacted" },
+    { "ip": "8.8.8.8", "expected": false, "id": "google_dns" },
+    { "ip": "8.8.4.4", "expected": false, "id": "google_dns_secondary" },
+    { "ip": "1.1.1.1", "expected": false, "id": "cloudflare_dns" },
+    { "ip": "208.67.222.222", "expected": false, "id": "opendns" },
+    { "ip": "9.9.9.9", "expected": false, "id": "quad9" },
+    { "ip": "192.0.2.1", "expected": false, "id": "test_net_1" },
+    { "ip": "203.0.113.1", "expected": false, "id": "test_net_3" },
+    { "ip": "198.51.100.1", "expected": false, "id": "test_net_2" },
+    { "ip": "192.167.1.1", "expected": false, "id": "192_167_not_private" },
+    { "ip": "192.169.1.1", "expected": false, "id": "192_169_not_private" },
+    { "ip": "11.0.0.1", "expected": false, "id": "11_not_private" }
   ],
   "parse_target_cases": [
-    {"target": "https://example.com",           "expected_host": "example.com",      "scheme": "https", "id": "https_url"},
-    {"target": "http://example.com",            "expected_host": "example.com",      "scheme": "http",  "id": "http_url"},
-    {"target": "https://example.com/",          "expected_host": "example.com",      "scheme": "https", "id": "https_trailing_slash"},
-    {"target": "https://example.com/path/page", "expected_host": "example.com",      "scheme": "https", "id": "https_with_path"},
-    {"target": "http://example.com:8080",       "expected_host": "example.com:8080", "scheme": "http",  "id": "http_with_port"},
-    {"target": "https://192.168.1.1:8443",      "expected_host": "192.168.1.1:8443", "scheme": "https", "id": "https_ip_with_port"},
-    {"target": "example.com",                   "expected_host": "example.com",      "scheme": null,    "id": "hostname_only"},
-    {"target": "sub.example.com",               "expected_host": "sub.example.com",  "scheme": null,    "id": "subdomain"},
-    {"target": "router.local",                  "expected_host": "router.local",     "scheme": null,    "id": "local_hostname"},
-    {"target": "192.168.1.1",                   "expected_host": "192.168.1.1",      "scheme": null,    "id": "ipv4_address"},
-    {"target": "192.168.1.1:8080",              "expected_host": "192.168.1.1:8080", "scheme": null,    "id": "ipv4_with_port"},
-    {"target": "10.0.0.1",                      "expected_host": "10.0.0.1",         "scheme": null,    "id": "private_ip"},
-    {"target": "HTTPS://EXAMPLE.COM",           "expected_host": "EXAMPLE.COM",      "scheme": "https", "id": "uppercase_scheme"},
-    {"target": "http://localhost",              "expected_host": "localhost",         "scheme": "http",  "id": "localhost"},
-    {"target": "http://127.0.0.1",              "expected_host": "127.0.0.1",        "scheme": "http",  "id": "loopback_ip"}
+    {
+      "target": "https://example.com",
+      "expected_host": "example.com",
+      "scheme": "https",
+      "id": "https_url"
+    },
+    {
+      "target": "http://example.com",
+      "expected_host": "example.com",
+      "scheme": "http",
+      "id": "http_url"
+    },
+    {
+      "target": "https://example.com/",
+      "expected_host": "example.com",
+      "scheme": "https",
+      "id": "https_trailing_slash"
+    },
+    {
+      "target": "https://example.com/path/page",
+      "expected_host": "example.com",
+      "scheme": "https",
+      "id": "https_with_path"
+    },
+    {
+      "target": "http://example.com:8080",
+      "expected_host": "example.com:8080",
+      "scheme": "http",
+      "id": "http_with_port"
+    },
+    {
+      "target": "https://192.168.1.1:8443",
+      "expected_host": "192.168.1.1:8443",
+      "scheme": "https",
+      "id": "https_ip_with_port"
+    },
+    {
+      "target": "example.com",
+      "expected_host": "example.com",
+      "scheme": null,
+      "id": "hostname_only"
+    },
+    {
+      "target": "sub.example.com",
+      "expected_host": "sub.example.com",
+      "scheme": null,
+      "id": "subdomain"
+    },
+    {
+      "target": "router.local",
+      "expected_host": "router.local",
+      "scheme": null,
+      "id": "local_hostname"
+    },
+    {
+      "target": "192.168.1.1",
+      "expected_host": "192.168.1.1",
+      "scheme": null,
+      "id": "ipv4_address"
+    },
+    {
+      "target": "192.168.1.1:8080",
+      "expected_host": "192.168.1.1:8080",
+      "scheme": null,
+      "id": "ipv4_with_port"
+    },
+    {
+      "target": "10.0.0.1",
+      "expected_host": "10.0.0.1",
+      "scheme": null,
+      "id": "private_ip"
+    },
+    {
+      "target": "HTTPS://EXAMPLE.COM",
+      "expected_host": "EXAMPLE.COM",
+      "scheme": "https",
+      "id": "uppercase_scheme"
+    },
+    {
+      "target": "http://localhost",
+      "expected_host": "localhost",
+      "scheme": "http",
+      "id": "localhost"
+    },
+    {
+      "target": "http://127.0.0.1",
+      "expected_host": "127.0.0.1",
+      "scheme": "http",
+      "id": "loopback_ip"
+    }
   ],
   "wait_for_pending_data_cases": [
-    {"id": "immediate_zero",       "pending_values": [0],           "timeout_s": 1.0, "expect_timeout": false, "description": "returns immediately when pending is 0"},
-    {"id": "drains_to_zero",       "pending_values": [3, 2, 1, 0], "timeout_s": 1.0, "expect_timeout": false, "description": "waits until pending drains to 0"},
-    {"id": "stays_pending",        "pending_values": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1], "timeout_s": 0.5,  "expect_timeout": true, "description": "times out when requests never complete (timeout_s=0.5 not 0.05: tighter values flake under local CPU pressure when 1969 other tests compete; CI's clean container hid this for releases)"},
-    {"id": "evaluate_exception",   "pending_values": "exception",  "timeout_s": 1.0, "expect_timeout": false, "description": "returns on page.evaluate exception"}
+    {
+      "id": "immediate_zero",
+      "pending_values": [0],
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "returns immediately when pending is 0"
+    },
+    {
+      "id": "drains_to_zero",
+      "pending_values": [3, 2, 1, 0],
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "waits until pending drains to 0"
+    },
+    {
+      "id": "stays_pending",
+      "pending_values": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      "timeout_s": 0.5,
+      "expect_timeout": true,
+      "description": "times out when requests never complete (timeout_s=0.5 not 0.05: tighter values flake under local CPU pressure when 1969 other tests compete; CI's clean container hid this for releases)"
+    },
+    {
+      "id": "evaluate_exception",
+      "pending_values": "exception",
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "returns on page.evaluate exception"
+    }
   ],
   "wait_for_quiescence_cases": [
-    {"id": "already_quiet",      "pending_values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "returns when already quiescent"},
-    {"id": "activity_then_quiet", "pending_values": [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "waits through activity then detects quiescence"},
-    {"id": "never_quiet",        "pending_values": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0], "quiescence_s": 5.0,  "timeout_s": 0.5,  "expect_timeout": true, "description": "times out when activity oscillates (timeout_s=0.5 not 0.05; same flake mode as stays_pending)"},
-    {"id": "evaluate_exception", "pending_values": "exception",    "quiescence_s": 0.01, "timeout_s": 1.0, "expect_timeout": false, "description": "returns on page.evaluate exception"}
+    {
+      "id": "already_quiet",
+      "pending_values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "quiescence_s": 0.01,
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "returns when already quiescent"
+    },
+    {
+      "id": "activity_then_quiet",
+      "pending_values": [2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "quiescence_s": 0.01,
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "waits through activity then detects quiescence"
+    },
+    {
+      "id": "never_quiet",
+      "pending_values": [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0],
+      "quiescence_s": 5.0,
+      "timeout_s": 0.5,
+      "expect_timeout": true,
+      "description": "times out when activity oscillates (timeout_s=0.5 not 0.05; same flake mode as stays_pending)"
+    },
+    {
+      "id": "evaluate_exception",
+      "pending_values": "exception",
+      "quiescence_s": 0.01,
+      "timeout_s": 1.0,
+      "expect_timeout": false,
+      "description": "returns on page.evaluate exception"
+    }
   ],
   "output_path_cases": [
-    {"id": "har_suffix_preserved",   "input": "capture.har",   "expected_suffix": ".har"},
-    {"id": "non_har_gets_har",       "input": "capture.json",  "expected_suffix": ".har"},
-    {"id": "no_ext_gets_har",        "input": "capture",       "expected_suffix": ".har"}
+    {
+      "id": "har_suffix_preserved",
+      "input": "capture.har",
+      "expected_suffix": ".har"
+    },
+    {
+      "id": "non_har_gets_har",
+      "input": "capture.json",
+      "expected_suffix": ".har"
+    },
+    { "id": "no_ext_gets_har", "input": "capture", "expected_suffix": ".har" }
   ],
   "capture_error_cases": [
-    {"id": "playwright_not_installed",   "mock_check_pw": false, "expect_error": "Playwright not installed"},
-    {"id": "connectivity_failure",       "mock_connectivity": [false, "http", "Connection refused"], "expect_error": "Connection refused"}
+    {
+      "id": "playwright_not_installed",
+      "mock_check_pw": false,
+      "expect_error": "Playwright not installed"
+    },
+    {
+      "id": "connectivity_failure",
+      "mock_connectivity": [false, "http", "Connection refused"],
+      "expect_error": "Connection refused"
+    }
   ],
   "browser_selection_cases": [
-    {"id": "chromium", "browser": "chromium", "launch_attr": "chromium"},
-    {"id": "firefox",  "browser": "firefox",  "launch_attr": "firefox"},
-    {"id": "webkit",   "browser": "webkit",   "launch_attr": "webkit"}
+    { "id": "chromium", "browser": "chromium", "launch_attr": "chromium" },
+    { "id": "firefox", "browser": "firefox", "launch_attr": "firefox" },
+    { "id": "webkit", "browser": "webkit", "launch_attr": "webkit" }
   ],
   "inject_metadata_cases": [
-    {"id": "all_metadata",  "has_probes": true,  "has_cookies": true,  "has_storage": true,  "has_popups": false},
-    {"id": "probes_only",   "has_probes": true,  "has_cookies": false, "has_storage": false, "has_popups": false},
-    {"id": "cookies_only",  "has_probes": false, "has_cookies": true,  "has_storage": false, "has_popups": false},
-    {"id": "storage_only",  "has_probes": false, "has_cookies": false, "has_storage": true,  "has_popups": false},
-    {"id": "empty_session", "has_probes": false, "has_cookies": false, "has_storage": false, "has_popups": false},
-    {"id": "with_popups",   "has_probes": false, "has_cookies": false, "has_storage": false, "has_popups": true}
+    {
+      "id": "all_metadata",
+      "has_probes": true,
+      "has_cookies": true,
+      "has_storage": true,
+      "has_popups": false,
+      "has_dialogs": true
+    },
+    {
+      "id": "probes_only",
+      "has_probes": true,
+      "has_cookies": false,
+      "has_storage": false,
+      "has_popups": false,
+      "has_dialogs": false
+    },
+    {
+      "id": "cookies_only",
+      "has_probes": false,
+      "has_cookies": true,
+      "has_storage": false,
+      "has_popups": false,
+      "has_dialogs": false
+    },
+    {
+      "id": "storage_only",
+      "has_probes": false,
+      "has_cookies": false,
+      "has_storage": true,
+      "has_popups": false,
+      "has_dialogs": false
+    },
+    {
+      "id": "empty_session",
+      "has_probes": false,
+      "has_cookies": false,
+      "has_storage": false,
+      "has_popups": false,
+      "has_dialogs": false
+    },
+    {
+      "id": "with_popups",
+      "has_probes": false,
+      "has_cookies": false,
+      "has_storage": false,
+      "has_popups": true,
+      "has_dialogs": false
+    },
+    {
+      "id": "with_dialogs",
+      "has_probes": false,
+      "has_cookies": false,
+      "has_storage": false,
+      "has_popups": false,
+      "has_dialogs": true
+    }
   ]
 }

--- a/tests/test_capture/test_browser.py
+++ b/tests/test_capture/test_browser.py
@@ -35,6 +35,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from har_capture.capture.browser import (
+    _DIALOG_OBSERVER_INIT_SCRIPT,
+    _WAIT_FOR_DATA_INIT_SCRIPT,
     BrowserSessionResult,
     CaptureOptions,
     _add_capture_metadata,
@@ -1486,7 +1488,7 @@ class TestWaitForData:
         )
 
         if expect_init_js:
-            mock_page.add_init_script.assert_called_once()
+            mock_page.add_init_script.assert_called_once_with(_WAIT_FOR_DATA_INIT_SCRIPT)
         else:
             mock_page.add_init_script.assert_not_called()
 
@@ -2269,6 +2271,155 @@ class TestPopupHandler:
         )
 
 
+class TestDialogHandler:
+    """Behavior of the ``page.on('dialog', ...)`` handler.
+
+    Dialog capture is enabled only for interactive headed runs. These
+    tests reach into the mocked page event registration to exercise the
+    real handler closure and confirm the inferred browser-UI outcome is
+    recorded into ``_solentlabs.dialogs`` metadata.
+    """
+
+    @staticmethod
+    def _extract_dialog_handler(mock_page: MagicMock) -> Any:
+        """Find the ``page.on('dialog', handler)`` call and return the handler."""
+        for call in mock_page.on.call_args_list:
+            if call[0][0] == "dialog":
+                return call[0][1]
+        raise AssertionError(f"page.on('dialog', ...) never invoked; calls: {mock_page.on.call_args_list}")
+
+    @pytest.mark.parametrize(
+        ("headless", "timeout", "expect_dialog_capture"),
+        [
+            (False, None, True),
+            (True, None, False),
+            (False, 1, False),
+        ],
+        ids=["interactive_headed", "headless", "timed"],
+    )
+    @patch("har_capture.capture.browser.check_playwright", return_value=True)
+    @patch("har_capture.capture.browser.check_device_connectivity")
+    @patch("playwright.sync_api.sync_playwright")
+    def test_dialog_capture_boundary(
+        self,
+        mock_sync_pw: MagicMock,
+        mock_connectivity: MagicMock,
+        mock_check_pw: MagicMock,
+        tmp_path: Path,
+        headless: bool,
+        timeout: int | None,
+        expect_dialog_capture: bool,
+    ) -> None:
+        """Dialog capture is limited to interactive headed runs."""
+        mock_pw = MagicMock()
+        mock_sync_pw.return_value.__enter__.return_value = mock_pw
+        mock_connectivity.return_value = (True, "http", None)
+
+        mock_context = mock_pw.chromium.launch.return_value.new_context.return_value
+        mock_page = mock_context.new_page.return_value
+        mock_page.evaluate.side_effect = lambda expr: (
+            [] if expr == "window.__harCaptureDialogOutcomes || []" else {}
+        )
+        mock_page.wait_for_event.side_effect = RuntimeError("stop interactive wait")
+
+        capture_device_har(
+            ip="127.0.0.1",
+            output=str(tmp_path / "test.har"),
+            headless=headless,
+            timeout=timeout,
+            sanitize=False,
+            compress=False,
+            wait_for_data=False,
+        )
+
+        if expect_dialog_capture:
+            mock_page.add_init_script.assert_called_once_with(_DIALOG_OBSERVER_INIT_SCRIPT)
+            mock_page.on.assert_any_call("dialog", unittest.mock.ANY)
+        else:
+            dialog_calls = [c for c in mock_page.on.call_args_list if c[0][0] == "dialog"]
+            assert dialog_calls == []
+            assert _DIALOG_OBSERVER_INIT_SCRIPT not in [
+                c.args[0] for c in mock_page.add_init_script.call_args_list
+            ]
+
+    @patch("har_capture.capture.browser.check_playwright", return_value=True)
+    @patch("har_capture.capture.browser.check_device_connectivity")
+    @patch("playwright.sync_api.sync_playwright")
+    def test_dialog_handler_records_browser_ui_outcome_in_har(
+        self,
+        mock_sync_pw: MagicMock,
+        mock_connectivity: MagicMock,
+        mock_check_pw: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Dialog handler logs the inferred browser-UI outcome into HAR metadata."""
+        import os
+
+        mock_pw = MagicMock()
+        mock_sync_pw.return_value.__enter__.return_value = mock_pw
+        mock_connectivity.return_value = (True, "http", None)
+
+        mock_context = mock_pw.chromium.launch.return_value.new_context.return_value
+        mock_page = mock_context.new_page.return_value
+        mock_context.cookies.return_value = []
+        mock_context.storage_state.return_value = {"cookies": [], "origins": []}
+
+        def evaluate_side_effect(expression: str) -> Any:
+            if expression == "window.__harCaptureDialogOutcomes || []":
+                return [{"action": "dismiss"}]
+            if expression == "() => Object.fromEntries(Object.entries(sessionStorage))":
+                return {}
+            return 0
+
+        mock_page.evaluate.side_effect = evaluate_side_effect
+
+        def on_side_effect(event_name: str, handler: Any) -> None:
+            if event_name == "dialog":
+                dialog = MagicMock()
+                dialog.type = "confirm"
+                dialog.message = "Are you sure?"
+                dialog.default_value = ""
+                handler(dialog)
+
+        mock_page.on.side_effect = on_side_effect
+
+        har_data = {
+            "log": {
+                "version": "1.2",
+                "creator": {"name": "test", "version": "1.0"},
+                "entries": [],
+            }
+        }
+        temp_har = tmp_path / "temp_capture.har"
+        temp_har.write_text(json.dumps(har_data))
+
+        output = tmp_path / "dialog.har"
+        fd = os.open(str(temp_har), os.O_RDWR)
+        with patch("tempfile.mkstemp", return_value=(fd, str(temp_har))):
+            capture_device_har(
+                ip="127.0.0.1",
+                output=str(output),
+                headless=False,
+                timeout=None,
+                sanitize=False,
+                compress=False,
+                keep_raw=True,
+                wait_for_data=False,
+            )
+
+        raw_har = json.loads(output.read_text())
+        dialogs = raw_har["log"]["_solentlabs"]["dialogs"]
+        assert len(dialogs) == 1
+        assert dialogs[0] == {
+            "type": "confirm",
+            "message": "Are you sure?",
+            "default_value": "",
+            "opened_at": dialogs[0]["opened_at"],
+            "action": "dismiss",
+            "resolved_by": "browser_ui",
+        }
+
+
 class TestInjectHarMetadataUnit:
     """Tests for _inject_har_metadata — zero mocks, real temp files."""
 
@@ -2291,6 +2442,14 @@ class TestInjectHarMetadataUnit:
 
         probes = {"auth_challenge": {"status": 401}} if case["has_probes"] else None
         popup_record = {"url": "http://10.0.0.1/popup", "opened_at": "2026-05-02T10:00:00"}
+        dialog_record = {
+            "type": "confirm",
+            "message": "Are you sure?",
+            "default_value": "",
+            "opened_at": "2026-05-02T10:01:00",
+            "action": "dismiss",
+            "resolved_by": "browser_ui",
+        }
         session = BrowserSessionResult(
             browser_cookies=[{"name": "SID", "value": "abc"}] if case["has_cookies"] else [],
             web_storage_local=(
@@ -2300,6 +2459,7 @@ class TestInjectHarMetadataUnit:
             ),
             web_storage_session={"token": "xyz"} if case["has_storage"] else {},
             pre_capture_cookies=[],
+            dialogs=[dialog_record] if case.get("has_dialogs") else [],
             popups=[popup_record] if case.get("has_popups") else [],
         )
 
@@ -2310,6 +2470,11 @@ class TestInjectHarMetadataUnit:
 
         # _solentlabs.pre_capture_cookies is always present
         assert log["_solentlabs"]["pre_capture_cookies"] == []
+
+        if case.get("has_dialogs"):
+            assert log["_solentlabs"]["dialogs"] == [dialog_record]
+        else:
+            assert log["_solentlabs"]["dialogs"] == []
 
         # _solentlabs.popups round-trips whatever the session carried.
         # Empty for sessions where no popup occurred (the common case);


### PR DESCRIPTION
## Summary

This should address the gap where Playwright's default behavior auto-dismisses browser dialogs before the user can interact with them during interactive capture.

For headed, user-driven runs, the capture flow now watches for browser dialogs, lets the user resolve them in the browser UI, and records the resulting dialog metadata in `_solentlabs.dialogs` for downstream HAR analysis.

While working through the dialog path, this PR also backfills the missing popup documentation so both browser-event audit surfaces are described consistently.

Dialog shown working in ui:
<img width="877" height="359" alt="image" src="https://github.com/user-attachments/assets/6f1c7bc0-0167-42a9-9320-f3e89a26369e" />

```json
#Example data from har capture:

"_solentlabs": {
    "pre_capture_cookies": [],
    "popups": [],
    "dialogs": [
        {
            "type": "confirm",
            "message": "Are you sure you want to reset the modem?",
            "default_value": "",
            "opened_at": "2026-05-08T15:11:47",
            "action": "dismiss",
            "resolved_by": "browser_ui"
        },
        {
            "type": "confirm",
            "message": "Are you sure you want to reset the modem?",
            "default_value": "",
            "opened_at": "2026-05-08T15:12:00",
            "action": "accept",
            "resolved_by": "browser_ui"
        }
    ]
}
```
Logging in terminal for user reference.
```log
============================================================
HAR CAPTURE
============================================================

  Target:     https://192.168.100.1
  Browser:    chromium
  Output:     manual.har

Checking connectivity...
  Connected:  https://192.168.100.1/

Instructions:
  1. Interact with the site when the browser opens
  2. Visit all pages you want to capture
  3. IMPORTANT: Wait 3-5 seconds on each page for data to load!
  4. Close the browser window when done

[har-capture dialog] confirm: Are you sure you want to reset the modem?
[har-capture dialog] resolved_by=browser_ui action=dismiss confirm: Are you sure you want to reset the modem?
[har-capture dialog] confirm: Are you sure you want to reset the modem?
[har-capture dialog] resolved_by=browser_ui action=accept confirm: Are you sure you want to reset the modem?

============================================================
CAPTURE COMPLETE
============================================================
```

## Changes

- stop relying on Playwright's default auto-dismiss behavior for interactive headed runs
- watch for browser dialogs, surface them to the user, and record the resolved outcome in _solentlabs
- add opened_at timestamps so repeated dialogs are captured as distinct events for HAR analysis
- add test coverage for dialog capture and run the full test suite to check for regressions
- document dialog behavior and backfill the missing popup coverage in the capture docs

## Testing

- [X] Tests pass locally (`pytest`)
- [X] Linting passes (`ruff check .`)
- [X] Type checking passes (`mypy src/`)

## Related Issues

Related to #46

## Checklist

- [X] Code follows project style guidelines
- [X] Self-review completed
- [X] Documentation updated (if applicable)
- [X] CHANGELOG.md updated (if applicable)
