### PR TITLE
fix: preserve base64-encoded JSON response structure; correct stale CLI docs

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -31,5 +31,16 @@
     "code_blocks": false,
     "tables": false,
     "headings": true
+  },
+
+  // MD024 no-duplicate-heading: scoped to siblings only.
+  //
+  // CHANGELOG.md (Keep a Changelog) repeats `### Added` / `### Changed` /
+  // `### Fixed` under every `## [version]` section — valid by design. The
+  // default flags these doc-wide; siblings_only restricts the rule to
+  // duplicates under the *same* parent heading, which is the real smell.
+  // Fires on CHANGELOG.md at commit time (pre-commit lints the changed file).
+  "MD024": {
+    "siblings_only": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-06-18
+
+### Fixed
+
+- **Base64-encoded JSON response bodies are sanitized in place, not collapsed.** Devices that return data as raw
+  base64-encoded JSON (e.g. Sercomm DM1000 `setup.cgi?todo=...` endpoints, often with an empty Content-Type) decode to a
+  colon-bearing string, which tripped the opaque-credential guard and replaced the entire body with a single
+  `AUTH_<hash>` token — destroying field names and JSON shape. `_sanitize_response_content` now runs a decode-first
+  discriminator: a body that base64-decodes to a JSON object or array is sanitized value-by-value and re-encoded,
+  preserving structure; only genuinely token-shaped values fall through to whole-body redaction. `base64(user:pass)`
+  values in unrecognized form/query field names (e.g. `pws`) are now also redacted, mirroring the query-param fallback.
+
+- **Post-capture "Next steps" suggestions include the required `--patterns` flag.** The `get` command's printed
+  `sanitize`/`validate` follow-up commands omitted `--patterns` (required since 0.9.0), so copy-pasting them errored.
+  They now echo the patterns used for the capture.
+
 ## [0.10.0] - 2026-05-30
 
 ### Added
@@ -879,6 +895,7 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.1.1]: https://github.com/solentlabs/har-capture/compare/v0.1.0...v0.1.1
 [0.1.2]: https://github.com/solentlabs/har-capture/compare/v0.1.1...v0.1.2
 [0.10.0]: https://github.com/solentlabs/har-capture/compare/v0.9.1...v0.10.0
+[0.10.1]: https://github.com/solentlabs/har-capture/compare/v0.10.0...v0.10.1
 [0.2.0]: https://github.com/solentlabs/har-capture/compare/v0.1.2...v0.2.0
 [0.2.1]: https://github.com/solentlabs/har-capture/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/solentlabs/har-capture/compare/v0.2.1...v0.2.2
@@ -906,4 +923,4 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
 [0.9.0]: https://github.com/solentlabs/har-capture/compare/v0.8.2...v0.9.0
 [0.9.1]: https://github.com/solentlabs/har-capture/compare/v0.9.0...v0.9.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.10.1...HEAD

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ PII removal. Perfect for support diagnostics, security reviews, and test fixture
 
 ```bash
 pip install har-capture[full]
-python -m har_capture https://example.com
+python -m har_capture get https://example.com --patterns network-device
 ```
 
 ### macOS / Linux
 
 ```bash
 pip install har-capture[full]
-har-capture https://example.com
+har-capture get https://example.com --patterns network-device
 ```
 
 ### Already have a HAR file?
@@ -104,7 +104,7 @@ ______________________________________________________________________
 
 ```bash
 # Capture and sanitize a network device (cable modem, router, AP)
-har-capture https://192.168.100.1 --patterns network-device
+har-capture get https://192.168.100.1 --patterns network-device
 
 # Sanitize an existing HAR with universal PII rules only (no device domain)
 har-capture sanitize capture.har --patterns base
@@ -170,13 +170,13 @@ ______________________________________________________________________
 
 ## What Gets Sanitized
 
-| Category        | Examples              | Output                                               |
-| --------------- | --------------------- | ---------------------------------------------------- |
-| **Network**     | IPs, MACs             | `192.168.1.1` → `10.255.42.17`                       |
-| **Personal**    | Emails, phones        | `user@example.com` → `user_a1b2@redacted.invalid`    |
-| **Credentials** | Passwords, tokens     | `password=secret` → `password=PASS_a1b2c3d4`         |
-| **Device**      | Serials, WiFi, SSIDs  | `SN123456` → `SERIAL_a1b2c3d4`                       |
-| **HTTP**        | Auth headers, cookies | `Cookie: session=xyz` → `Cookie: session=TOKEN_a1b2` |
+| Category        | Examples              | Output                                                                      |
+| --------------- | --------------------- | --------------------------------------------------------------------------- |
+| **Network**     | IPs, MACs             | `192.168.1.1` → `10.255.42.17` (private), `8.8.8.8` → `192.0.2.42` (public) |
+| **Personal**    | Emails, phones        | `user@example.com` → `user_a1b2@redacted.invalid`                           |
+| **Credentials** | Passwords, tokens     | `password=secret` → `password=PASS_a1b2c3d4`                                |
+| **Device**      | Serials, WiFi, SSIDs  | `SN123456` → `SERIAL_a1b2c3d4`                                              |
+| **HTTP**        | Auth headers, cookies | `Cookie: session=xyz` → `Cookie: session=TOKEN_a1b2`                        |
 
 [See complete PII categories list →](docs/PII_CATEGORIES.md)
 

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -36,6 +36,7 @@ words:
   - qpsk
   - RDWR
   - SECLEVEL
+  - Sercomm
   - SJCL
   - sjcl
   - SNMP

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -48,36 +48,33 @@ har-capture get <TARGET> --patterns <DOMAIN>
 
 #### Sanitization Options (get)
 
-- `--salt TEXT` - Consistent salt for correlation (default: random)
-- `--no-salt` - Use static placeholders instead of salted hashes
+- `--no-sanitize` - Skip automatic sanitization (keep the raw capture)
 - `--patterns NAME|PATH` - **Required.** Pattern domain name (e.g. `network-device`), `base` for universal PII only, or
   a custom JSON path. Repeatable. Run `har-capture patterns` to list available domains.
 
-Interactive review of flagged values is always enabled after capture.
+Auto-sanitization after capture uses a random salt. To control the correlation salt, capture with `--no-sanitize` and
+run `har-capture sanitize --salt ...` separately. Interactive review of flagged values is always enabled after capture.
 
 ### Examples (get)
 
 ```bash
 # Basic capture (outputs: example.com.sanitized.har.gz)
-har-capture https://example.com --patterns base
-
-# Explicit 'get' subcommand (equivalent)
 har-capture get https://example.com --patterns base
 
+# The 'get' is optional — a bare 'har-capture <target>' infers it
+har-capture https://example.com --patterns base
+
 # Bare hostname — scheme auto-detected (HTTPS preferred when reachable)
-har-capture 192.168.100.1 --patterns network-device
+har-capture get 192.168.100.1 --patterns network-device
 
 # Custom output path
-har-capture http://192.168.1.1 --output modem.har --patterns network-device
+har-capture get http://192.168.1.1 --output modem.har --patterns network-device
 
 # Keep raw unsanitized file for debugging
-har-capture https://example.com --keep-raw --patterns base
-
-# Use consistent salt for correlation across captures
-har-capture https://example.com --salt my-debug-key --patterns base
+har-capture get https://example.com --keep-raw --patterns base
 
 # Disable async data wait for faster capture of simple sites
-har-capture https://example.com --no-wait-for-data --patterns base
+har-capture get https://example.com --no-wait-for-data --patterns base
 ```
 
 ### Pre-flight Checks (get)
@@ -254,7 +251,7 @@ User captures and sanitizes HAR file for support ticket:
 
 ```bash
 # User runs this
-har-capture https://myapp.example.com --patterns base
+har-capture get https://myapp.example.com --patterns base
 
 # Outputs: myapp.example.com.sanitized.har.gz
 # User attaches to support ticket
@@ -265,8 +262,9 @@ har-capture https://myapp.example.com --patterns base
 Generate sanitized test fixtures:
 
 ```bash
-# Capture with consistent salt for reproducible output
-har-capture get https://api.example.com --salt test-fixture-key --output api_test.har --patterns base
+# Capture raw, then sanitize with a consistent salt for reproducible output
+har-capture get https://api.example.com --no-sanitize --output api_test.har --patterns base
+har-capture sanitize api_test.har --salt test-fixture-key --patterns base
 ```
 
 ### Batch Processing (validate)

--- a/docs/CORRELATION.md
+++ b/docs/CORRELATION.md
@@ -46,7 +46,7 @@ har-capture uses standardized reserved ranges to ensure output doesn't conflict 
 ### Auto (Default)
 
 ```bash
-har-capture sanitize capture.har
+har-capture sanitize capture.har --patterns base
 ```
 
 - Random salt generated per session
@@ -58,7 +58,7 @@ har-capture sanitize capture.har
 ### Consistent Salt
 
 ```bash
-har-capture sanitize capture.har --salt my-secret-key
+har-capture sanitize capture.har --salt my-secret-key --patterns base
 ```
 
 - Same salt used across multiple runs
@@ -70,7 +70,7 @@ har-capture sanitize capture.har --salt my-secret-key
 ### Static Placeholders (Legacy)
 
 ```bash
-har-capture sanitize capture.har --no-salt
+har-capture sanitize capture.har --no-salt --patterns base
 ```
 
 - All IPs become `192.0.2.1`

--- a/docs/CUSTOM_PATTERNS.md
+++ b/docs/CUSTOM_PATTERNS.md
@@ -431,7 +431,8 @@ Alternatively, use the Python API which accepts pattern dictionaries that can be
 1. **Check regex syntax**: Test with online regex tools
 1. **Check case sensitivity**: Add `"case_sensitive": false`
 1. **Check escaping**: Ensure special chars are escaped
-1. **Enable verbose mode**: `har-capture sanitize --verbose`
+1. **Inspect what was detected**: `har-capture sanitize capture.har --patterns my_patterns.json --report report.json`
+   and review the JSON report
 
 ### Over-Redacting
 

--- a/docs/INTERACTIVE_SANITIZATION.md
+++ b/docs/INTERACTIVE_SANITIZATION.md
@@ -8,10 +8,10 @@ don't match standard patterns.
 
 ```bash
 # Sanitize and review flagged values
-har-capture sanitize device.har
+har-capture sanitize device.har --patterns network-device
 
 # Also save a detailed JSON report
-har-capture sanitize device.har --report sanitization-report.json
+har-capture sanitize device.har --patterns network-device --report sanitization-report.json
 ```
 
 ## How It Works
@@ -94,7 +94,7 @@ Passwords/credentials are pre-selected by default, but you can adjust any select
 ### Basic Interactive Review
 
 ```bash
-har-capture sanitize device.har
+har-capture sanitize device.har --patterns network-device
 ```
 
 Output:
@@ -124,7 +124,7 @@ Sanitized: device.sanitized.har
 ### Generate Report for Later Review
 
 ```bash
-har-capture sanitize device.har --report review.json
+har-capture sanitize device.har --patterns network-device --report review.json
 ```
 
 The report contains:
@@ -162,7 +162,7 @@ The report contains:
 When no terminal is available, flagged values are written to a report file instead of prompting:
 
 ```bash
-har-capture sanitize device.har 2>&1
+har-capture sanitize device.har --patterns network-device 2>&1
 # Note: No terminal detected. Writing flagged values to report instead.
 # Sanitized: device.sanitized.har
 # Report: device.har.review.json

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -85,11 +85,11 @@ ______________________________________________________________________
 
 ```bash
 # Scheme auto-detected (HTTPS preferred when reachable)
-har-capture 192.168.1.1 --patterns network-device
+har-capture get 192.168.1.1 --patterns network-device
 
 # Explicit scheme bypasses auto-detection
-har-capture http://192.168.1.1 --patterns network-device
-har-capture http://192.168.100.1 --output modem_capture.har --patterns network-device
+har-capture get http://192.168.1.1 --patterns network-device
+har-capture get http://192.168.100.1 --output modem_capture.har --patterns network-device
 ```
 
 ______________________________________________________________________
@@ -277,7 +277,7 @@ ______________________________________________________________________
 **CLI Example**:
 
 ```bash
-har-capture http://192.168.1.1 \ --patterns network-device
+har-capture get http://192.168.1.1 \
     --username admin --password pass123 \
     --patterns network-device --output captures/modem.har
 ```
@@ -427,7 +427,7 @@ ______________________________________________________________________
 ```bash
 har-capture sanitize capture.har --patterns network-device
 # Interactive table shown, user selects values
-har-capture sanitize capture.har --report flagged.json  # Save report to file --patterns network-device
+har-capture sanitize capture.har --report flagged.json --patterns network-device  # Save report to file
 ```
 
 ______________________________________________________________________
@@ -572,9 +572,8 @@ modem with `max_concurrent: 1`).
 **CLI Example**:
 
 ```bash
-har-capture http://192.168.100.1 --minimal --patterns network-device
-har-capture http://192.168.100.1 --minimal --patterns network-device
-har-capture http://192.168.100.1 --minimal --username admin --password pass123 --patterns network-device
+har-capture get http://192.168.100.1 --minimal --patterns network-device
+har-capture get http://192.168.100.1 --minimal --username admin --password pass123 --patterns network-device
 ```
 
 ______________________________________________________________________

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -158,8 +158,11 @@ def sanitize_post_data(
 ```
 
 1. **Form params** (`postData.params`): Each parameter checked against `is_sensitive_field()` (auto-redact) and
-   `is_flaggable_field()` (flag).
-1. **URL-encoded body** (`_sanitize_form_urlencoded`): Detected via content type, parsed and redacted.
+   `is_flaggable_field()` (flag). A parameter whose name is not recognized but whose value is a `base64(user:pass)`
+   credential (`is_base64_credential()`) is redacted as `AUTH` — mirroring the query-param fallback, so base64-wrapped
+   credentials in device-specific field names (e.g. `pws`) do not slip past field-name redaction.
+1. **URL-encoded body** (`_sanitize_form_urlencoded`): Detected via content type, parsed and redacted. The same
+   `base64(user:pass)` value fallback applies (checking the raw and percent-decoded forms).
 1. **JSON body** (`_sanitize_json_recursive`): Recursive traversal with depth limit (50). Object keys checked against
    field patterns; values redacted if key is sensitive.
 1. **XML body** (`sanitize_html`): Detected via `text/xml` or `application/xml` content type. Delegated to the HTML
@@ -204,7 +207,15 @@ def _sanitize_json_recursive(data, collector, depth=0, max_depth=50):
 def _sanitize_response_content(content, collector, custom_patterns, heuristics):
 ```
 
-MIME-type based routing:
+**Decode-first discriminator** (`_decode_base64_json`): Before any MIME routing, a body made entirely of base64-alphabet
+characters is tested — if it decodes to UTF-8 that parses as a JSON **object or array**, it is a structured payload, not
+an opaque secret. Such bodies are sanitized value-by-value via `_sanitize_json_recursive` and **re-encoded to base64**
+on the way out, preserving field names and shape. This stops devices that return raw base64-encoded JSON (e.g. the
+Sercomm DM1000 `setup.cgi?todo=...` endpoints, often with an empty Content-Type) from being collapsed to a single
+`AUTH_<hash>` token. Only genuinely token-shaped opaque values (base64 that does not decode to structured JSON) fall
+through to the whole-body credential guard — see [Server-Token Preservation](#server-token-preservation).
+
+MIME-type based routing (after the decode-first check):
 
 - `text/html`, `text/xml`, `application/xml` → `sanitize_html()` from html.py
 - `application/json`, `text/json` → `_sanitize_json_recursive()`
@@ -593,7 +604,8 @@ For `url_token` auth flows the server responds with an opaque session token in t
 `base64(user:pass)` URL credential. That token is a server-issued artifact, not a user secret, and must be preserved for
 HAR replay fidelity.
 
-**Problem**: The response-body credential guard (`_sanitize_response_content`) fires on any body that
+**Problem**: After the [decode-first discriminator](#response-content-dispatch) rules out structured base64-JSON
+payloads, the response-body credential guard (`_sanitize_response_content`) fires on any remaining body that
 `is_base64_credential()` matches — including server tokens that happen to decode to the `x:y` format.
 
 **Heuristic** (`_is_echoed_credential`): When the entry's request URL contained a base64 credential, the response body

--- a/docs/specs/VALIDATION_SPEC.md
+++ b/docs/specs/VALIDATION_SPEC.md
@@ -281,7 +281,7 @@ Key design decisions:
 ### `har-capture validate` CLI Command
 
 ```bash
-har-capture validate capture.har [--patterns custom.json]
+har-capture validate capture.har --patterns <domain|custom.json>
 ```
 
 - Loads and validates a single HAR file
@@ -299,7 +299,7 @@ Consumers who commit HAR files to their repositories can configure a pre-commit 
   hooks:
     - id: check-har-secrets
       name: Check HAR files for secrets
-      entry: har-capture validate
+      entry: har-capture validate --patterns base
       files: '\.har(\.gz)?$'
       types: [file]
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.10.0"
+version = "0.10.1"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/scripts/pii_test_server.py
+++ b/scripts/pii_test_server.py
@@ -21,7 +21,7 @@ Usage:
     python scripts/pii_test_server.py --port 9090    # custom port
 
 Then in another terminal:
-    har-capture get http://localhost:8080
+    har-capture get http://localhost:8080 --patterns base
 """
 
 from __future__ import annotations
@@ -390,8 +390,8 @@ def main() -> None:  # noqa: D103
     print("    (all)       Web Storage: localStorage + sessionStorage PII on every page")
     print()
     print("Test with:")
-    print(f"  har-capture get http://{args.host}:{args.port}")
-    print(f"  har-capture get http://{args.host}:{args.port} -u {USERNAME} -p '{PASSWORD}'")
+    print(f"  har-capture get http://{args.host}:{args.port} --patterns base")
+    print(f"  har-capture get http://{args.host}:{args.port} -u {USERNAME} -p '{PASSWORD}' --patterns base")
     print()
     print("Press Ctrl+C to stop.")
     print()

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/cli/capture.py
+++ b/src/har_capture/cli/capture.py
@@ -109,10 +109,10 @@ def capture(
         minimal: Minimal pre-flight for single-session devices
 
     Example:
-        har-capture https://example.com
-        har-capture 192.168.100.1                # auto-detect HTTP vs HTTPS
-        har-capture http://192.168.100.1 --output capture.har
-        har-capture get http://router.local --include-images
+        har-capture get https://example.com --patterns base
+        har-capture get 192.168.100.1 --patterns network-device   # auto-detect HTTP vs HTTPS
+        har-capture get http://192.168.100.1 --output capture.har --patterns network-device
+        har-capture get http://router.local --include-images --patterns network-device
     """
     # Validate --patterns up front so a user running `har-capture get URL`
     # without choosing a domain gets the listing error before we trigger
@@ -223,7 +223,7 @@ def capture(
         raise typer.Exit(1)
 
     # Display results
-    _display_results(result)
+    _display_results(result, patterns)
 
     # Interactive review of flagged values (always enabled)
     if result.capture and result.capture.sanitization_report:
@@ -254,7 +254,7 @@ def _display_instructions() -> None:
     typer.echo()
 
 
-def _display_results(result: CaptureWorkflowResult) -> None:
+def _display_results(result: CaptureWorkflowResult, patterns: list[str] | None = None) -> None:
     """Display capture results."""
     typer.echo()
     typer.echo("=" * 60)
@@ -282,12 +282,16 @@ def _display_results(result: CaptureWorkflowResult) -> None:
         result.compressed_path and ".sanitized" in str(result.compressed_path)
     )
 
+    # --patterns is required on sanitize/validate; echo the ones used for this
+    # capture so the suggested commands are copy-paste ready.
+    patterns_args = " ".join(f"--patterns {p}" for p in patterns) if patterns else "--patterns <domain>"
+
     typer.echo("Next steps:")
     if is_sanitized:
         typer.echo(f"  • Share the file (PII removed): {main_file}")
     else:
-        typer.echo(f"  • Sanitize before sharing: har-capture sanitize {main_file}")
-    typer.echo(f"  • Validate for secrets:    har-capture validate {main_file}")
+        typer.echo(f"  • Sanitize before sharing: har-capture sanitize {main_file} {patterns_args}")
+    typer.echo(f"  • Validate for secrets:    har-capture validate {main_file} {patterns_args}")
     typer.echo()
 
     if is_sanitized:

--- a/src/har_capture/cli/main.py
+++ b/src/har_capture/cli/main.py
@@ -79,10 +79,10 @@ def main(
 
     \b
     Examples:
-        har-capture https://example.com
-        har-capture http://192.168.1.1 --output capture.har
-        har-capture sanitize myfile.har
-        har-capture validate myfile.har
+        har-capture get https://example.com --patterns base
+        har-capture get http://192.168.1.1 --output capture.har --patterns network-device
+        har-capture sanitize myfile.har --patterns network-device
+        har-capture validate myfile.har --patterns network-device
     """
 
 

--- a/src/har_capture/cli/sanitize.py
+++ b/src/har_capture/cli/sanitize.py
@@ -92,13 +92,13 @@ def sanitize(
         report: Write JSON report to file
 
     Example:
-        har-capture sanitize device.har
-        har-capture sanitize device.har --output clean.har --compress
-        har-capture sanitize device.har --salt my-key  # Consistent hashing
-        har-capture sanitize device.har --no-salt  # Static placeholders
-        har-capture sanitize device.har --max-size 500  # Allow up to 500MB
-        har-capture sanitize device.har --max-size 0  # No size limit
-        har-capture sanitize device.har --report sanitize-report.json
+        har-capture sanitize device.har --patterns network-device
+        har-capture sanitize device.har --patterns network-device --output clean.har --compress
+        har-capture sanitize device.har --patterns network-device --salt my-key  # Consistent hashing
+        har-capture sanitize device.har --patterns network-device --no-salt  # Static placeholders
+        har-capture sanitize device.har --patterns network-device --max-size 500  # Allow up to 500MB
+        har-capture sanitize device.har --patterns network-device --max-size 0  # No size limit
+        har-capture sanitize device.har --patterns network-device --report sanitize-report.json
     """
     from har_capture.sanitization import HarSizeError, HarValidationError, sanitize_har_file
 

--- a/src/har_capture/sanitization/har.py
+++ b/src/har_capture/sanitization/har.py
@@ -572,6 +572,10 @@ def _sanitize_form_urlencoded(
                     f"form field '{key}'",
                     f"Flaggable field name '{key}' in form data",
                 )
+            elif is_base64_credential(value) or is_base64_credential(urllib.parse.unquote_plus(value)):
+                # base64(user:pass) value in an unrecognized field name (e.g.
+                # 'pws') — check the raw and percent-decoded forms.
+                value = _redact_value(value, hasher, "AUTH", collector)
             pairs.append(f"{key}={value}")
         else:
             pairs.append(pair)
@@ -651,6 +655,10 @@ def sanitize_post_data(
                             f"POST param '{param['name']}'",
                             f"Flaggable field name '{param['name']}' in POST params",
                         )
+                    elif is_base64_credential(param.get("value", "")):
+                        # base64(user:pass) value in an unrecognized field name
+                        # (e.g. 'pws') — mirrors the queryString fallback.
+                        param["value"] = _redact_value(param["value"], hasher, "AUTH", collector)
 
         # Sanitize raw text (form-urlencoded, JSON, or XML)
         if result.get("text"):
@@ -1149,6 +1157,48 @@ def _sanitize_request(
         req["url"] = _sanitize_url_path(req["url"], hasher, collector)
 
 
+# A body made entirely of base64-alphabet characters is a candidate for
+# base64-encoded-JSON decoding (see _decode_base64_json). Cheap pre-filter so
+# HTML/JSON/text bodies bail before a full decode attempt.
+_BASE64_BODY_RE = re.compile(r"^[A-Za-z0-9+/=]+$")
+
+
+def _decode_base64_json(value: str) -> Any | None:
+    """Decode a base64 body into a structured JSON payload, if it is one.
+
+    Some devices return their data as raw base64-encoded JSON (often with an
+    empty Content-Type). The decoded text is colon-bearing, so it would
+    otherwise trip the opaque-credential heuristic and be collapsed to a single
+    ``AUTH_`` token — destroying the field names and JSON shape, which are not
+    PII. This discriminator answers "payload or secret?": it returns the parsed
+    object only when ``value`` is valid base64 that decodes to UTF-8 parsing as
+    a JSON object or array. Scalars, non-JSON, and non-base64 inputs return
+    ``None`` so the caller falls back to opaque-token handling.
+
+    Args:
+        value: Candidate base64 string (already stripped).
+
+    Returns:
+        The parsed dict/list, or ``None`` when ``value`` is not base64-encoded
+        JSON (object/array).
+    """
+    if not value or not _BASE64_BODY_RE.match(value):
+        return None
+    try:
+        decoded = base64.b64decode(value, validate=True).decode("utf-8")
+    except ValueError:
+        # binascii.Error (bad alphabet/padding) and UnicodeDecodeError are both
+        # ValueError subclasses.
+        return None
+    try:
+        parsed = json.loads(decoded)
+    except ValueError:  # includes json.JSONDecodeError
+        return None
+    if isinstance(parsed, dict | list):
+        return parsed
+    return None
+
+
 def _sanitize_response_content(
     content: dict[str, Any],
     collector: RedactionCollector | None = None,
@@ -1175,6 +1225,19 @@ def _sanitize_response_content(
     hasher = collector.hasher if collector else None
 
     stripped = content["text"].strip()
+
+    # Decode-first discriminator: a base64-encoded *structured* payload (JSON
+    # object or array) must be sanitized value-by-value with its structure
+    # intact — never collapsed to a single AUTH_ token. Devices like the Sercomm
+    # DM1000 return data as raw base64 JSON (empty Content-Type), which decodes
+    # to a colon-bearing string and would otherwise trip the opaque-credential
+    # branch below. Re-encode to base64 on the way out, matching how it arrived.
+    decoded_json = _decode_base64_json(stripped)
+    if decoded_json is not None:
+        sanitized = _sanitize_json_recursive(decoded_json, hasher, collector)
+        content["text"] = base64.b64encode(json.dumps(sanitized).encode()).decode()
+        return
+
     if is_base64_credential(stripped):
         if url_cred_raw is None or _is_echoed_credential(stripped, url_cred_raw):
             content["text"] = _redact_value(stripped, hasher, "AUTH", collector)

--- a/tests/test_capture/test_integration.py
+++ b/tests/test_capture/test_integration.py
@@ -517,6 +517,21 @@ class TestPopupCapture:
 # a future refactor that renames either side would fail these tests.
 
 
+@pytest.fixture(scope="class")
+def playwright_browser() -> Generator[Any, None, None]:
+    """Class-scoped headless Chromium shared by the dialog integration tests.
+
+    Defined at module scope (not as an instance method): pytest 9.1+ rejects
+    class-scoped fixtures declared as instance methods.
+    """
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
 @pytest.mark.slow
 @pytest.mark.integration
 @skip_no_browser
@@ -605,16 +620,6 @@ class TestDialogObserverIntegration:
         page.goto(self._data_url(trigger_js), wait_until="load")
 
         return opens, resolutions
-
-    @pytest.fixture(scope="class")
-    def playwright_browser(self) -> Generator[Any, None, None]:
-        """Module-scoped headless Chromium for all dialog tests."""
-        from playwright.sync_api import sync_playwright
-
-        with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
-            yield browser
-            browser.close()
 
     def test_alert_records_accept(self, playwright_browser: Any) -> None:
         """``alert()`` has no dismiss path — only accept. Bridge records action=accept."""

--- a/tests/test_cli/test_capture.py
+++ b/tests/test_cli/test_capture.py
@@ -130,6 +130,36 @@ def test_display_results(
         assert s in captured.out, f"{desc}: expected '{s}' in output"
 
 
+def test_display_results_suggestions_include_patterns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Next-steps suggestions echo the --patterns used so they are copy-paste ready."""
+    from har_capture.capture.workflow import CaptureResult, CaptureWorkflowResult
+    from har_capture.cli.capture import _display_results
+
+    result = CaptureWorkflowResult(capture=CaptureResult(success=True, har_path=Path("output/capture.har")))
+
+    _display_results(result, ["network-device", "./extras.json"])
+
+    out = capsys.readouterr().out
+    assert "har-capture sanitize output/capture.har --patterns network-device --patterns ./extras.json" in out
+    assert "har-capture validate output/capture.har --patterns network-device --patterns ./extras.json" in out
+
+
+def test_display_results_suggestions_placeholder_when_no_patterns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """With no patterns supplied, suggestions fall back to a <domain> placeholder."""
+    from har_capture.capture.workflow import CaptureResult, CaptureWorkflowResult
+    from har_capture.cli.capture import _display_results
+
+    result = CaptureWorkflowResult(capture=CaptureResult(success=True, har_path=Path("output/capture.har")))
+
+    _display_results(result)
+
+    assert "--patterns <domain>" in capsys.readouterr().out
+
+
 # =============================================================================
 # _run_interactive_review() — branches over a CaptureWorkflowResult
 # =============================================================================

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import base64
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -33,6 +34,7 @@ from har_capture.patterns import Hasher
 from har_capture.sanitization.collector import RedactionCollector
 from har_capture.sanitization.har import (
     HarValidationError,
+    _decode_base64_json,
     _detect_client_side_cookies,
     _detect_url_credential_entries,
     _embed_sanitization_metadata,
@@ -2417,6 +2419,256 @@ class TestServerTokenPreservation:
             assert result_body == response_body, f"{desc}: server token should be preserved"
         else:
             assert result_body != response_body, f"{desc}: credential should be redacted"
+
+
+# ── base64-encoded response bodies & credential values ───────────────────────
+# base64(user:pass) strings are opaque credentials; base64(JSON) is a payload.
+_B64_OBJECT = base64.b64encode(b'{"a": 1, "b": {"c": 2}}').decode()
+_B64_ARRAY = base64.b64encode(b'[{"x": 1}, {"y": 2}]').decode()
+_B64_SCALAR_NUM = base64.b64encode(b"42").decode()
+_B64_SCALAR_STR = base64.b64encode(b'"just-a-string"').decode()
+_B64_NON_JSON = base64.b64encode(b"admin:password").decode()
+_B64_NON_UTF8 = base64.b64encode(b"\xff\xfe\xfa\xfb").decode()
+_B64_USERPASS = base64.b64encode(b"admin:hunter2").decode()
+
+# base64-JSON object/array each carry a MAC that must be redacted *in place*;
+# an opaque base64(user:pass) body must collapse to a single AUTH placeholder.
+_B64_JSON_OBJECT_PII = base64.b64encode(json.dumps({"mac": "AA:BB:CC:DD:EE:FF", "ch": 1}).encode()).decode()
+_B64_JSON_ARRAY_PII = base64.b64encode(
+    json.dumps([{"mac": "AA:BB:CC:DD:EE:FF"}, {"ch": 2}]).encode()
+).decode()
+_B64_OPAQUE_CRED = base64.b64encode(b"admin:supersecret").decode()
+
+# fmt: off
+DECODE_BASE64_JSON_CASES = [
+    # (value, is_structured, desc)
+    (_B64_OBJECT,      True,  "base64_json_object"),
+    (_B64_ARRAY,       True,  "base64_json_array"),
+    (_B64_SCALAR_NUM,  False, "base64_json_scalar_number"),
+    (_B64_SCALAR_STR,  False, "base64_json_scalar_string"),
+    (_B64_NON_JSON,    False, "base64_non_json_colon_string"),
+    (_B64_NON_UTF8,    False, "base64_non_utf8_bytes"),
+    ('{"a": 1}',       False, "plain_json_not_base64"),
+    ("<html></html>",  False, "html_not_base64"),
+    ("",               False, "empty_string"),
+]
+
+RESPONSE_BASE64_BODY_CASES = [
+    # (body, structure_preserved, desc)
+    (_B64_JSON_OBJECT_PII, True,  "base64_json_object_preserved"),
+    (_B64_JSON_ARRAY_PII,  True,  "base64_json_array_preserved"),
+    (_B64_OPAQUE_CRED,     False, "opaque_credential_collapsed"),
+]
+
+# base64(user:pass) in an unrecognized field name ('pws' is not default-sensitive)
+# must be redacted by the value fallback — identically across param surfaces.
+BASE64_CRED_PARAM_CASES = [
+    # (desc, request_fragment, accessor)
+    (
+        "post_param",
+        {"postData": {"mimeType": "application/x-www-form-urlencoded",
+                      "params": [{"name": "pws", "value": _B64_USERPASS}]}},
+        lambda r: r["request"]["postData"]["params"][0]["value"],
+    ),
+    (
+        "query_param",
+        {"queryString": [{"name": "pws", "value": _B64_USERPASS}]},
+        lambda r: r["request"]["queryString"][0]["value"],
+    ),
+]
+
+# Benign params (not sensitive, not flaggable, not base64-credential by value or
+# name) fall through every redaction branch untouched.
+BENIGN_PARAM_CASES = [
+    # (desc, request_fragment, accessor)
+    (
+        "post_param",
+        {"postData": {"mimeType": "application/x-www-form-urlencoded",
+                      "params": [{"name": "format", "value": "json"}]}},
+        lambda r: r["request"]["postData"]["params"][0],
+    ),
+    (
+        "query_param",
+        {"queryString": [{"name": "format", "value": "json"}]},
+        lambda r: r["request"]["queryString"][0],
+    ),
+]
+# fmt: on
+
+
+def _entry_with_response_body(body: str) -> dict[str, Any]:
+    """Minimal HAR entry whose response body is ``body`` with an empty Content-Type."""
+    return {
+        "request": {"method": "GET", "url": "http://192.168.0.1/setup.cgi?todo=status", "headers": []},
+        "response": {"status": 200, "headers": [], "content": {"text": body, "mimeType": ""}},
+    }
+
+
+class TestBase64JsonResponseStructure:
+    """Base64-encoded JSON response bodies keep structure; opaque tokens collapse.
+
+    Some devices (e.g. the Sercomm DM1000) return data as raw base64-encoded JSON
+    from ``setup.cgi?todo=...`` endpoints with an empty Content-Type. The decoded
+    body is colon-bearing, so the opaque-credential heuristic used to collapse the
+    whole payload into a single ``AUTH_`` token, destroying every field name and
+    the JSON shape. Structure (not PII) must survive — only values are redacted.
+    """
+
+    @pytest.mark.parametrize(
+        ("body", "structure_preserved", "desc"),
+        RESPONSE_BASE64_BODY_CASES,
+        ids=[c[2] for c in RESPONSE_BASE64_BODY_CASES],
+    )
+    def test_base64_body_preserved_or_collapsed(
+        self, body: str, structure_preserved: bool, desc: str
+    ) -> None:
+        result = sanitize_entry(_entry_with_response_body(body), salt=None)
+        out_text = result["response"]["content"]["text"]
+        if structure_preserved:
+            decoded = json.loads(base64.b64decode(out_text).decode())
+            assert isinstance(decoded, dict | list), desc
+            assert "AA:BB:CC:DD:EE:FF" not in out_text, desc  # MAC redacted in place
+        else:
+            assert out_text == "***AUTH***", desc
+
+    def test_field_names_and_benign_values_survive(self) -> None:
+        """A base64-JSON body keeps field names + benign values; only PII is redacted."""
+        payload = {
+            "status": "ok",
+            "downstream": [{"channel": 1, "power": "-7.0", "snr": "38.5"}],
+            "lan_mac": "AA:BB:CC:DD:EE:FF",
+            "password": "hunter2",
+        }
+        body_b64 = base64.b64encode(json.dumps(payload).encode()).decode()
+
+        result = sanitize_entry(_entry_with_response_body(body_b64), salt=None)
+        decoded = json.loads(base64.b64decode(result["response"]["content"]["text"]).decode())
+
+        assert set(decoded) == {"status", "downstream", "lan_mac", "password"}
+        assert decoded["status"] == "ok"
+        assert decoded["downstream"][0] == {"channel": 1, "power": "-7.0", "snr": "38.5"}
+        assert decoded["lan_mac"] != "AA:BB:CC:DD:EE:FF"  # value-pattern redaction
+        assert decoded["password"] != "hunter2"  # sensitive field-name redaction
+
+
+class TestDecodeBase64Json:
+    """Unit tests for the _decode_base64_json payload-vs-secret discriminator."""
+
+    @pytest.mark.parametrize(
+        ("value", "is_structured", "desc"),
+        DECODE_BASE64_JSON_CASES,
+        ids=[c[2] for c in DECODE_BASE64_JSON_CASES],
+    )
+    def test_decode_base64_json(self, value: str, is_structured: bool, desc: str) -> None:
+        result = _decode_base64_json(value)
+        if is_structured:
+            assert isinstance(result, dict | list), desc
+        else:
+            assert result is None, desc
+
+
+class TestBase64CredentialInFields:
+    """base64(user:pass) values in unrecognized field names are redacted everywhere.
+
+    Mirrors the query-string base64-credential fallback across param surfaces: a
+    value in a field like ``pws`` (not default-sensitive) used to slip past
+    field-name redaction while sibling ``passwd``/``cur_passwd`` were redacted.
+    """
+
+    @pytest.mark.parametrize(
+        ("desc", "request_fragment", "accessor"),
+        BASE64_CRED_PARAM_CASES,
+        ids=[c[0] for c in BASE64_CRED_PARAM_CASES],
+    )
+    def test_base64_credential_value_redacted(
+        self, desc: str, request_fragment: dict[str, Any], accessor: Any
+    ) -> None:
+        entry = {
+            "request": {"method": "POST", "url": "http://device/login", "headers": [], **request_fragment},
+            "response": {"status": 200, "headers": [], "content": {}},
+        }
+        result = sanitize_entry(entry, salt=None)
+        assert accessor(result) == "***AUTH***", desc
+
+    @pytest.mark.parametrize(
+        ("desc", "request_fragment", "accessor"),
+        BENIGN_PARAM_CASES,
+        ids=[c[0] for c in BENIGN_PARAM_CASES],
+    )
+    def test_benign_param_preserved(self, desc: str, request_fragment: dict[str, Any], accessor: Any) -> None:
+        """A param that matches no redaction branch passes through untouched."""
+        entry = {
+            "request": {"method": "POST", "url": "http://device/status", "headers": [], **request_fragment},
+            "response": {"status": 200, "headers": [], "content": {}},
+        }
+        result = sanitize_entry(entry, salt=None)
+        param = accessor(result)
+        assert param == {"name": "format", "value": "json"}, desc
+
+    def test_malformed_querystring_entries_skipped(self) -> None:
+        """Non-dict and name-less queryString entries are left untouched, not errored."""
+        entry = {
+            "request": {
+                "method": "GET",
+                "url": "http://device/status",
+                "headers": [],
+                "queryString": ["not-a-dict", {"label": "x"}],
+            },
+            "response": {"status": 200, "headers": [], "content": {}},
+        }
+        result = sanitize_entry(entry, salt=None)
+        assert result["request"]["queryString"] == ["not-a-dict", {"label": "x"}]
+
+    def test_malformed_cookie_entries_skipped(self) -> None:
+        """Non-dict and value-less request cookies are left untouched, not errored."""
+        entry = {
+            "request": {
+                "method": "GET",
+                "url": "http://device/status",
+                "headers": [],
+                "cookies": ["not-a-dict", {"name": "n"}],
+            },
+            "response": {"status": 200, "headers": [], "content": {}},
+        }
+        result = sanitize_entry(entry, salt=None)
+        assert result["request"]["cookies"] == ["not-a-dict", {"name": "n"}]
+
+    def test_request_without_url_is_tolerated(self) -> None:
+        """A request with no 'url' key skips URL sanitization without erroring."""
+        entry = {
+            "request": {"method": "GET", "headers": []},
+            "response": {"status": 200, "headers": [], "content": {}},
+        }
+        result = sanitize_entry(entry, salt=None)
+        assert "url" not in result["request"]
+
+    def test_sibling_named_fields_and_form_text(self) -> None:
+        """Named siblings redact by name; the base64 cred redacts by value (params + text)."""
+        post_data = {
+            "mimeType": "application/x-www-form-urlencoded",
+            "params": [
+                {"name": "passwd", "value": "secret"},
+                {"name": "cur_passwd", "value": "classified"},
+                {"name": "pws", "value": _B64_USERPASS},
+            ],
+            "text": f"passwd=secret&cur_passwd=classified&pws={_B64_USERPASS}",
+        }
+
+        result = sanitize_post_data(post_data)
+        assert result is not None
+        params = {p["name"]: p["value"] for p in result["params"]}
+        assert params["passwd"] == "[REDACTED]"
+        assert params["cur_passwd"] == "[REDACTED]"
+        assert params["pws"] == "[REDACTED]"  # base64 value fallback
+        assert _B64_USERPASS not in result["text"]
+
+    def test_percent_encoded_base64_credential_in_form_text(self) -> None:
+        """A percent-encoded base64(user:pass) value is caught via the unquote fallback."""
+        encoded = _B64_USERPASS.replace("=", "%3D")  # padding no longer base64-charset
+        result = _sanitize_form_urlencoded(f"user=admin&pws={encoded}")
+        assert encoded not in result
+        assert _B64_USERPASS not in result
+        assert "pws=[REDACTED]" in result
 
 
 # ┌──────────────────────────────┬──────────────┬──────────────────────────────────────────────────────┬──────────────────────────────────────┐


### PR DESCRIPTION
Two distinct fixes (separate commits):

## fix(sanitization): base64-encoded JSON response bodies (cb08c87)
Base64-encoded JSON decodes to a colon-bearing string, so the opaque-credential
heuristic collapsed the **whole** response body to a single `AUTH_` token —
destroying field names and JSON shape (e.g. Sercomm DM1000 `setup.cgi`
responses). Adds a **decode-first discriminator** (`_decode_base64_json`):
base64 that decodes to a JSON object/array is sanitized value-by-value and
re-encoded, preserving structure; only genuinely token-shaped values fall
through to whole-body redaction. Also redacts `base64(user:pass)` values in
unrecognized form/query fields (e.g. `pws`), mirroring the query-param fallback.
`SANITIZATION_SPEC.md` updated; cspell dictionary gains `Sercomm`.

## fix(cli): required --patterns + stale docs (0800fa3)
Post-capture "Next steps" now echo the `--patterns` used, so suggested
`sanitize`/`validate` commands are copy-paste ready. Aligns README,
CLI_REFERENCE, USE_CASES, CORRELATION, CUSTOM_PATTERNS, INTERACTIVE_SANITIZATION,
VALIDATION_SPEC and CLI docstrings with the `get` subcommand and the required
`--patterns` flag (0.9.0+); removes references to non-existent `--salt`-on-`get`
and `--verbose` options.

## Testing
- `pytest -m "not integration"`: 2161 passed; coverage 94.78% (`har.py` 98%).
- `pre-commit run --all-files`: clean.

## Follow-up (this PR, before merge)
- CHANGELOG `[Unreleased]` entries + version bump per `docs/RELEASE.md` (both are `Fixed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
