### PR TITLE
fix(sanitization): redact serials and WPS PINs split across sibling elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Serial numbers and WPS PINs split across sibling HTML elements are now redacted.** Technicolor .jst firmware
+  (XB6/XB7/XB8 family) renders the label and value in separate sibling `<span>` elements with whitespace between the
+  tags (`<span class="readonlyLabel">Serial Number:</span>` followed by `<span class="value">`), which the label-based
+  patterns in `sanitize_html()` did not match — the tag chain permitted consecutive tags but not whitespace between
+  them. All label-based tag chains now tolerate whitespace between tags: the serial inline/table and WPS PIN passes in
+  the HTML engine, the `serial_number` / `wps_pin` patterns used by `check_for_pii()`, and the serial detectors in
+  `validate_har()`. Redaction now preserves the intermediate markup instead of collapsing it to `label: hash`, so
+  sanitized fixtures keep their DOM structure. Reported via an unredacted serial in a contributor capture
+  (cable_modem_monitor #101, Technicolor CGM4981COM `hardware.jst`).
+
 ## [0.10.1] - 2026-06-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-07
+
 ### Fixed
 
 - **Serial numbers and WPS PINs split across sibling HTML elements are now redacted.** Technicolor .jst firmware
@@ -908,6 +910,7 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.1.2]: https://github.com/solentlabs/har-capture/compare/v0.1.1...v0.1.2
 [0.10.0]: https://github.com/solentlabs/har-capture/compare/v0.9.1...v0.10.0
 [0.10.1]: https://github.com/solentlabs/har-capture/compare/v0.10.0...v0.10.1
+[0.10.2]: https://github.com/solentlabs/har-capture/compare/v0.10.1...v0.10.2
 [0.2.0]: https://github.com/solentlabs/har-capture/compare/v0.1.2...v0.2.0
 [0.2.1]: https://github.com/solentlabs/har-capture/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/solentlabs/har-capture/compare/v0.2.1...v0.2.2
@@ -935,4 +938,4 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
 [0.9.0]: https://github.com/solentlabs/har-capture/compare/v0.8.2...v0.9.0
 [0.9.1]: https://github.com/solentlabs/har-capture/compare/v0.9.0...v0.9.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.10.1...HEAD
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.10.2...HEAD

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -261,6 +261,7 @@ The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 
 | 2    | Serial numbers (inline)       | `\bSN\b\|S/N\|Serial Number` + value                | `hasher.hash_value(val, "SERIAL")`     |
 | 2b   | Serial numbers (table)        | `<td>Label\b</td><td>VALUE</td>`                    | `hasher.hash_value(val, "SERIAL")`     |
 | 2c   | JS serial variables           | Names with serial+Number/Num/No or ending in serial | `hasher.hash_value(val, "SERIAL")`     |
+| 2d   | WPS / pairing / default PINs  | Known PIN label + 8-digit value (issue #47)         | `hasher.hash_value(val, "PIN")`        |
 | 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value     | `hasher.hash_value(val, "ACCOUNT")`    |
 | 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)             | `hasher.hash_ip(ip, is_private=True)`  |
 | 5    | Public IPs                    | Non-private, non-reserved                           | `hasher.hash_ip(ip, is_private=False)` |
@@ -282,6 +283,14 @@ The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 
 **Pass 2c precision rule:** Matches variable names containing the compound `serial` + `number`/`num`/`no` (with optional
 separator), and names ending with `serial`. Does NOT match `serial` followed by unrelated suffixes (`Protocol`, `Port`,
 `Baud`, `ization`). Bare `serial` is excluded — too ambiguous for auto-redact.
+
+**Sibling-element rule (passes 2, 2b, 2d):** The tag chain between a label and its value — `(?:<[^>]*>\s*)*` — permits
+whitespace between tags, so label/value pairs rendered in sibling elements match (e.g. Technicolor .jst on the XB6/XB7/
+XB8 family renders `<span class="readonlyLabel">Serial Number:</span>` with the value in a following sibling
+`<span class="value">`). In passes 2 and 2d the separator-plus-tag run is captured and re-emitted verbatim, so redaction
+replaces only the value and preserves the intermediate markup — sanitized fixtures keep their DOM structure. The same
+whitespace-tolerant chain is used by the `serial_number` / `wps_pin` patterns in `pii.json` (`check_for_pii`) and the
+`SERIAL_PATTERNS` detectors in `validation/secrets.py`.
 
 ### Web Storage Scanner (Pass 0b)
 

--- a/docs/specs/VALIDATION_SPEC.md
+++ b/docs/specs/VALIDATION_SPEC.md
@@ -169,7 +169,9 @@ Severity: **error**
 
 **Serial numbers:**
 
-- Pattern: `SN|S/N|Serial Number|SerialNum` + value in HTML table cells
+- Pattern: `SN|S/N|Serial Number|SerialNum` + value — inline, in HTML table cells, or in sibling elements (tag chains
+  tolerate whitespace between tags, per the sibling-element rule in
+  [`SANITIZATION_SPEC.md`](SANITIZATION_SPEC.md#scanner-pipeline))
 - Checks via `is_redacted()` before reporting
 
 **Public IPs:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.10.1"
+version = "0.10.2"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/patterns/pii.json
+++ b/src/har_capture/patterns/pii.json
@@ -7,13 +7,13 @@
       "description": "MAC addresses in colon or dash format"
     },
     "serial_number": {
-      "regex": "(Serial\\s*Number|SerialNum|SN|S/N)\\b\\s*[:\\s=]*(?:<[^>]*>)*\\s*([a-zA-Z0-9\\-]{5,})",
+      "regex": "(Serial\\s*Number|SerialNum|SN|S/N)\\b\\s*[:\\s=]*(?:<[^>]*>\\s*)*([a-zA-Z0-9\\-]{5,})",
       "replacement_prefix": "SERIAL",
       "flags": ["IGNORECASE"],
-      "description": "Device serial numbers with various label formats"
+      "description": "Device serial numbers with various label formats; tag chain tolerates whitespace between tags so sibling-element label/value pairs match"
     },
     "wps_pin": {
-      "regex": "(WPS[\\s_-]*PIN|PIN[\\s_-]*Code|Pairing[\\s_-]*PIN|Default[\\s_-]*PIN)\\b\\s*[:\\s=]*(?:<[^>]*>)*\\s*(\\d{8})\\b",
+      "regex": "(WPS[\\s_-]*PIN|PIN[\\s_-]*Code|Pairing[\\s_-]*PIN|Default[\\s_-]*PIN)\\b\\s*[:\\s=]*(?:<[^>]*>\\s*)*(\\d{8})\\b",
       "replacement_prefix": "PIN",
       "flags": ["IGNORECASE"],
       "description": "WPS / pairing / default PIN labels followed by an 8-digit code (issue #47)"

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -423,15 +423,20 @@ def _sanitize_html_impl(
     html = re.sub(r"\b([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b", replace_mac, html)
 
     # 2. Serial Numbers (various label formats)
+    # The tag chain `(?:<[^>]*>\s*)*` tolerates whitespace between tags so
+    # label/value pairs in sibling elements match (Technicolor .jst renders
+    # <span>Serial Number:</span>\n<span class="value">\nVALUE</span>).
+    # The separator + tag run is captured and re-emitted verbatim so redaction
+    # replaces only the value and preserves the surrounding markup.
     def replace_serial(match: re.Match[str]) -> str:
         collector.record_auto_redaction("serial_number")
         label = match.group(1)
-        serial = match.group(2) if match.lastindex and match.lastindex >= 2 else ""
-        hashed = hasher.hash_generic(serial, "SERIAL") if serial else "***SERIAL***"
-        return f"{label}: {hashed}"
+        sep = match.group(2)
+        serial = match.group(3)
+        return f"{label}{sep}{hasher.hash_generic(serial, 'SERIAL')}"
 
     html = re.sub(
-        r"\b(Serial\s*Number|SerialNum|SN|S/N)\b\s*[:\s=]*(?:<[^>]*>)*\s*([a-zA-Z0-9\-]{5,})",
+        r"\b(Serial\s*Number|SerialNum|SN|S/N)\b(\s*[:\s=]*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-]{5,})",
         replace_serial,
         html,
         flags=re.IGNORECASE,
@@ -447,7 +452,7 @@ def _sanitize_html_impl(
         return f"{prefix}{hashed}"
 
     html = re.sub(
-        r"(<td[^>]*>(?:<[^>]*>)*\s*(?:Serial\s*Number|SerialNum|SN|S/N)\b\s*(?:<[^>]*>)*\s*</td>\s*<td[^>]*>(?:<[^>]*>)*\s*)([a-zA-Z0-9\-]{5,})(?=\s*(?:<[^>]*>)*\s*</td>)",
+        r"(<td[^>]*>\s*(?:<[^>]*>\s*)*(?:Serial\s*Number|SerialNum|SN|S/N)\b\s*(?:<[^>]*>\s*)*</td>\s*<td[^>]*>\s*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-]{5,})(?=\s*(?:<[^>]*>\s*)*</td>)",
         replace_serial_table,
         html,
         flags=re.IGNORECASE,
@@ -458,15 +463,17 @@ def _sanitize_html_impl(
     # safe pattern would have to be relaxed, drowning the review UI in counter
     # noise). The label is what makes the regex layer's 100% confidence bar
     # achievable. See issue #47 and docs/ARCHITECTURE.md § Confidence boundary.
+    # Tag chain and separator handling mirror pass 2: whitespace-tolerant
+    # sibling-element matching, with the separator + tag run preserved.
     def replace_wps_pin(match: re.Match[str]) -> str:
         collector.record_auto_redaction("wps_pin")
         label = match.group(1)
-        pin = match.group(2)
-        hashed = hasher.hash_generic(pin, "PIN")
-        return f"{label}: {hashed}"
+        sep = match.group(2)
+        pin = match.group(3)
+        return f"{label}{sep}{hasher.hash_generic(pin, 'PIN')}"
 
     html = re.sub(
-        r"(WPS[\s_-]*PIN|PIN[\s_-]*Code|Pairing[\s_-]*PIN|Default[\s_-]*PIN)\b\s*[:\s=]*(?:<[^>]*>)*\s*(\d{8})\b",
+        r"(WPS[\s_-]*PIN|PIN[\s_-]*Code|Pairing[\s_-]*PIN|Default[\s_-]*PIN)\b(\s*[:\s=]*(?:<[^>]*>\s*)*)(\d{8})\b",
         replace_wps_pin,
         html,
         flags=re.IGNORECASE,

--- a/src/har_capture/validation/secrets.py
+++ b/src/har_capture/validation/secrets.py
@@ -43,12 +43,14 @@ COOKIE_ATTRIBUTES_ONLY: list[str] = [
 MAC_PATTERN = re.compile(r"([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}")
 
 # Serial number patterns (manufacturer-specific)
+# Tag chains `(?:<[^>]*>\s*)*` tolerate whitespace between tags so serials whose
+# label and value sit in sibling elements (Technicolor .jst span pairs) are caught.
 SERIAL_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"serial[^:]*:\s*[A-Z0-9]{8,}", re.IGNORECASE),
-    re.compile(r"SN[:\s]+[A-Z0-9]{8,}", re.IGNORECASE),
+    re.compile(r"serial[^:]*:\s*(?:<[^>]*>\s*)*[A-Z0-9]{8,}", re.IGNORECASE),
+    re.compile(r"SN[:\s]+(?:<[^>]*>\s*)*[A-Z0-9]{8,}", re.IGNORECASE),
     # Serial numbers in HTML table cells (label in one td, value in next td)
     re.compile(
-        r"(?:Serial\s*Number|SerialNum|SN|S/N)\s*(?:</\w+>\s*)*</td>\s*<td[^>]*>(?:<[^>]*>)*\s*([A-Za-z0-9\-]{8,})",
+        r"(?:Serial\s*Number|SerialNum|SN|S/N)\s*(?:</\w+>\s*)*</td>\s*<td[^>]*>\s*(?:<[^>]*>\s*)*([A-Za-z0-9\-]{8,})",
         re.IGNORECASE,
     ),
 ]

--- a/tests/fixtures/test_html.json
+++ b/tests/fixtures/test_html.json
@@ -67,7 +67,9 @@
     {"content": "Device MAC: DE:AD:BE:EF:CA:FE",           "pattern_name": "mac_address",   "match": "DE:AD:BE:EF:CA:FE",  "id": "mac_detect"},
     {"content": "MAC: 11-22-33-44-55-66",                  "pattern_name": "mac_address",   "match": "11-22-33-44-55-66",  "id": "mac_dash_detect"},
     {"content": "Contact: admin@example.com",              "pattern_name": "email",         "match": "admin@example.com",  "id": "email_detect"},
-    {"content": "DNS: 8.8.8.8",                            "pattern_name": "public_ip",     "match": "8.8.8.8",            "id": "public_ip_detect"}
+    {"content": "DNS: 8.8.8.8",                            "pattern_name": "public_ip",     "match": "8.8.8.8",            "id": "public_ip_detect"},
+    {"content": "<span>Serial Number:</span> <span>ZZ99887766</span>", "pattern_name": "serial_number", "match": "Serial Number:</span> <span>ZZ99887766", "id": "serial_sibling_span_detect"},
+    {"content": "<span>WPS PIN:</span> <span>13572468</span>",         "pattern_name": "wps_pin",       "match": "WPS PIN:</span> <span>13572468",         "id": "wps_pin_sibling_span_detect"}
   ],
 
   "allowlisted_cases": [
@@ -85,6 +87,11 @@
     {"html": "<td>Serial Number</td><td>ABC12345678</td>",                       "serial_value": "ABC12345678",     "id": "serial_in_plain_td"},
     {"html": "<td><strong>SN</strong></td>\n<td>ARRIS-99887766</td>",            "serial_value": "ARRIS-99887766",  "id": "sn_label_in_td"},
     {"html": "<td>Model</td><td>SB8200</td>",                                    "serial_value": null,              "id": "non_serial_table_cell"}
+  ],
+
+  "serial_sibling_span_cases": [
+    {"html": "<div class=\"form-row odd\">\n\t<span class=\"readonlyLabel\" id=\"hardmess2\">Serial Number:</span>\n\t<span class=\"value\">\n\t1234567890123456</span>\n</div>", "redacted_value": "1234567890123456", "preserved_markup": "<span class=\"value\">", "id": "technicolor_sibling_span_serial"},
+    {"html": "<span class=\"readonlyLabel\">WPS PIN:</span>\n<span class=\"value\">\n13572468</span>",                                                                             "redacted_value": "13572468",         "preserved_markup": "<span class=\"value\">", "id": "sibling_span_wps_pin"}
   ],
 
   "setitem_cases": [

--- a/tests/fixtures/test_pii_regressions.json
+++ b/tests/fixtures/test_pii_regressions.json
@@ -67,6 +67,27 @@
       "expected_prefix": "PIN_",
       "id": "pairing_pin_equals",
       "source": "issue #47 — pairing-PIN label, equals separator"
+    },
+    {
+      "input_html": "<div class=\"form-row odd\">\n\t<span class=\"readonlyLabel\" id=\"hardmess2\">Serial Number:</span>\n\t<span class=\"value\">\n\t1234567890123456</span>\n</div>",
+      "leaked_value": "1234567890123456",
+      "expected_prefix": "SERIAL_",
+      "id": "technicolor_jst_sibling_span_serial",
+      "source": "cable_modem_monitor issue #101 — Technicolor CGM4981COM hardware.jst renders label and value in sibling spans with whitespace between the tags"
+    },
+    {
+      "input_html": "<span class=\"readonlyLabel\">WPS PIN:</span>\n<span class=\"value\">\n13572468</span>",
+      "leaked_value": "13572468",
+      "expected_prefix": "PIN_",
+      "id": "wps_pin_sibling_span",
+      "source": "cable_modem_monitor issue #101 — sibling-span markup applied to the WPS PIN label pattern, which shares the tag-chain construct"
+    },
+    {
+      "input_html": "<td>\n<strong>Serial Number</strong>\n</td>\n<td>\n9876543210ABCD</td>",
+      "leaked_value": "9876543210ABCD",
+      "expected_prefix": "SERIAL_",
+      "id": "serial_td_whitespace_between_tags",
+      "source": "cable_modem_monitor issue #101 — table-cell variant with newlines between tags, same tag-chain construct in the table pass"
     }
   ]
 }

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -67,6 +67,11 @@ ALLOWLISTED_CASES = [(c["content"], c["id"]) for c in _FIXTURE["allowlisted_case
 
 SERIAL_TABLE_CASES = [(c["html"], c["serial_value"], c["id"]) for c in _FIXTURE["serial_table_cases"]]
 
+SERIAL_SIBLING_SPAN_CASES = [
+    (c["html"], c["redacted_value"], c["preserved_markup"], c["id"])
+    for c in _FIXTURE["serial_sibling_span_cases"]
+]
+
 SETITEM_CASES = [
     (c["input_html"], c["should_not_contain"], c["should_contain"], c["id"])
     for c in _FIXTURE["setitem_cases"]
@@ -235,6 +240,35 @@ class TestSerialNumberTableCell:
             assert serial_value not in result, f"{desc}: serial should be redacted"
         else:
             assert result == html or "SB8200" in result, f"{desc}: non-serial should be preserved"
+
+
+# =============================================================================
+# Serial Number / PIN Labels in Sibling Elements (Technicolor .jst markup)
+# =============================================================================
+
+
+class TestSerialNumberSiblingSpans:
+    """Label and value in sibling elements with whitespace between the tags.
+
+    Technicolor .jst firmware (XB6/XB7/XB8 family) renders
+    ``<span class="readonlyLabel">Serial Number:</span>`` and the value in a
+    following sibling ``<span class="value">``. Redaction must replace only
+    the value and preserve the intermediate markup so sanitized fixtures keep
+    their DOM structure.
+    """
+
+    @pytest.mark.parametrize(
+        ("html", "redacted_value", "preserved_markup", "desc"),
+        SERIAL_SIBLING_SPAN_CASES,
+        ids=[c[3] for c in SERIAL_SIBLING_SPAN_CASES],
+    )
+    def test_sibling_span_value_redacted_markup_preserved(
+        self, html: str, redacted_value: str, preserved_markup: str, desc: str
+    ) -> None:
+        """Test values in sibling elements are redacted without collapsing markup."""
+        result = sanitize_html(html, salt="test")
+        assert redacted_value not in result, f"{desc}: value should be redacted"
+        assert preserved_markup in result, f"{desc}: intermediate markup should be preserved"
 
 
 # =============================================================================

--- a/tests/test_validation/test_secrets.py
+++ b/tests/test_validation/test_secrets.py
@@ -462,6 +462,28 @@ class TestCheckContentSerialInTable:
         serial_findings = [f for f in findings if "serial" in f.reason.lower()]
         assert len(serial_findings) >= 1, "Should flag serial number in table cell"
 
+    def test_serial_in_table_cell_with_whitespace_between_tags(self) -> None:
+        """Test check_content flags serials in td cells with newlines between tags."""
+        html = "<td>\n<strong>Serial Number</strong>\n</td>\n<td>\n<b>ARRIS99887766ZZ</b></td>"
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        serial_findings = [f for f in findings if "serial" in f.reason.lower()]
+        assert len(serial_findings) >= 1, "Should flag serial in whitespace-separated table cells"
+
+    def test_serial_in_sibling_spans(self) -> None:
+        """Test check_content flags serials split across sibling span elements.
+
+        Technicolor .jst markup — label and value in sibling spans with
+        whitespace between the tags (cable_modem_monitor issue #101).
+        """
+        html = (
+            '<span class="readonlyLabel">Serial Number:</span>\n<span class="value">\n1234567890123456</span>'
+        )
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        serial_findings = [f for f in findings if "serial" in f.reason.lower()]
+        assert len(serial_findings) >= 1, "Should flag serial number in sibling spans"
+
 
 class TestValidateHarBase64Content:
     """Tests for validate_har with base64-encoded response content."""


### PR DESCRIPTION
## Summary

`sanitize_html()` failed to redact serial numbers when the label and value sit in separate sibling elements with whitespace between the tags — the markup Technicolor .jst firmware (XB6/XB7/XB8 family) actually renders. Real-world evidence: an unredacted 16-digit serial in a contributor capture on cable_modem_monitor issue #101 (`hardware.jst`, Technicolor CGM4981COM).

**Root cause:** the tag chain `(?:<[^>]*>)*` in the label-based patterns permits consecutive tags but no whitespace between them, so `</span>` + newline + `<span class="value">` + value never matched. The table-cell fallback only handled `<td>` pairs.

**Fix:** every occurrence of the construct now uses the whitespace-tolerant form `(?:<[^>]*>\s*)*`:

- `sanitization/html.py` — pass 2 (inline serial), pass 2b (table-cell serial), pass 2d (WPS PIN). The MAC pass matches values by shape with no label/tag chain and was not affected.
- `patterns/pii.json` — the `serial_number` / `wps_pin` patterns used by `check_for_pii()`.
- `validation/secrets.py` — all three `SERIAL_PATTERNS` detectors in `validate_har()`, so a leaked span-pair serial is now also caught by the validation layer.

**Behavior change beyond the regex:** passes 2 and 2d previously rewrote matches as `label: hash`, which would have swallowed the sibling-span run and collapsed the markup. They now capture the separator-plus-tag run and re-emit it verbatim, replacing only the value — sanitized fixtures keep their DOM structure.

## Tests

Nine new cases, all written first and confirmed failing on v0.10.1: the exact Technicolor repro, a sibling-span WPS PIN, and a whitespace-between-tags table case in the regression fixture (sourced to cable_modem_monitor #101); a `TestSerialNumberSiblingSpans` class asserting both redaction and markup preservation; span-pair detection cases for `check_for_pii`; and two `check_content` tests for the validation layer.

Docs reconciled: SANITIZATION_SPEC gained a sibling-element rule and the previously missing pass-table row for 2d (WPS PIN); VALIDATION_SPEC serial section updated; CHANGELOG entry under Unreleased → Fixed.

## Follow-up (action stays in cable_modem_monitor)

CMM pins `har-capture~=0.9.0` for catalog-script use and will need a pin review once this fix releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)