### PR TITLE
fix(sanitization): redact secrets in URL path segments and hex-shaped values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-30
+
 ### Fixed
 
 - **Secrets in URL path segments no longer survive sanitization.** A token redacted in a response body and in an
@@ -1003,6 +1005,7 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.10.2]: https://github.com/solentlabs/har-capture/compare/v0.10.1...v0.10.2
 [0.10.3]: https://github.com/solentlabs/har-capture/compare/v0.10.2...v0.10.3
 [0.11.0]: https://github.com/solentlabs/har-capture/compare/v0.10.3...v0.11.0
+[0.11.1]: https://github.com/solentlabs/har-capture/compare/v0.11.0...v0.11.1
 [0.2.0]: https://github.com/solentlabs/har-capture/compare/v0.1.2...v0.2.0
 [0.2.1]: https://github.com/solentlabs/har-capture/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/solentlabs/har-capture/compare/v0.2.1...v0.2.2
@@ -1030,4 +1033,4 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
 [0.9.0]: https://github.com/solentlabs/har-capture/compare/v0.8.2...v0.9.0
 [0.9.1]: https://github.com/solentlabs/har-capture/compare/v0.9.0...v0.9.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.11.0...HEAD
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.11.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Secrets in URL path segments no longer survive sanitization.** A token redacted in a response body and in an
+  `Authorization` header could still appear verbatim in a URL path — `DELETE /rest/v1/user/3/token/<token>` — because a
+  path segment carries no field name for the strict rules to match on. Downstream PII validation did not catch it
+  either: an opaque hex string matches no MAC, IP, or serial pattern, so the capture passed a fixture scan while
+  carrying a live-shaped credential.
+
+  After every entry is sanitized, `sanitize_har` now sweeps the whole HAR once and replaces any remaining verbatim
+  occurrence of an already-redacted value with the placeholder that value was already given. No new detection is
+  involved — the value is one the strict rules already redacted, and the sweep only answers whether a textual match
+  elsewhere must be the same secret. To qualify, a value must be 16+ characters, drawn from `[A-Za-z0-9._~+/=:-]` with
+  no whitespace, contain at least one digit, and not be a known-safe shape. The digit requirement keeps identifiers like
+  `GetDeviceInformation` out; the length floor keeps values like `0` or `admin` from being find-replaced across a file.
+
+  A percent-encoded copy of the value is matched too, so a base64-shaped token that had to be escaped to sit in a URL
+  path is caught alongside its literal form and receives the same placeholder. Matching is exact and case-sensitive.
+
+  Substitution is one token for one token, so path segment count and URL shape are preserved. Values that do not qualify
+  keep the existing behavior and stay flagged for interactive review; values that were propagated are dropped from the
+  review queue, since the user's decision could no longer change the output. See
+  [`SANITIZATION_SPEC.md`](docs/specs/SANITIZATION_SPEC.md#pass-1b-redacted-value-propagation).
+
+- **Hex-encoded secrets are no longer classified as safe values.** The built-in IPv6 safe-value pattern (`^[0-9a-f:]+$`)
+  made its colon optional, so it matched *any* all-hex string. Because the safe-value check is the first gate in
+  `analyze_value()`, every session token, MD5, SHA-1 and SHA-256 digest was skipped before reaching the entropy check,
+  the domain detectors, or adjacency analysis — the heuristic layer was silently disabled for hex-shaped secrets
+  wherever it runs (the pipe-delimited scanner, passes 14–15, and the web-storage `setItem` scanner, pass 0b). The
+  pattern now requires at least one colon. Genuine IPv6 in every form — `::1`, `fe80::1`, `2001:db8::`, prefixed and
+  CIDR-suffixed — is unaffected, as are colon-bearing channel lists from domain pattern files.
+
+  Captures containing hex tokens in unlabeled positions will now surface more values for interactive review. That is the
+  intended posture: the heuristic layer flags shape-matching candidates aggressively and `safe_value_patterns` is where
+  reviewed-benign shapes are recorded.
+
 ## [0.11.0] - 2026-07-27
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -230,12 +230,18 @@ graph TD
     end
 
     raw[Raw HAR] --> pass1
-    pass1 --> sanitized[Sanitized HAR]
+    pass1 --> pass1b[Pass 1b: Propagate<br>Replace already-redacted values on unlabeled surfaces]
+    pass1b --> sanitized[Sanitized HAR]
     sanitized --> pass2[Pass 2: Interactive Review<br>Show flagged → user selects → apply redactions]
 ```
 
 **Pass 1** auto-sanitizes each entry: headers, cookies, POST data, query strings, URL paths, then response content
 (MIME-dispatched to the HTML engine, JSON traversal, or string pattern matching).
+
+**Pass 1b** sweeps the whole HAR once after every entry is done, replacing any remaining verbatim occurrence of an
+already-redacted value with the placeholder that value was assigned. This catches secrets on surfaces that carry no
+field name to match — most commonly a URL path segment. It adds no detection of its own; eligibility is a
+collision-safety test on values Pass 1 already redacted.
 
 **Pass 2** presents flagged values for interactive review (TTY) or writes them to a JSON report (CI/CD). User-selected
 redactions are applied via global find-and-replace using the same session salt.

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -259,3 +259,51 @@ and CLAUDE.md points at them rather than restating them.
   in CLAUDE.md is now an anti-pattern flagged explicitly in the AI Shortcut Audit ("Restating instead of pointing").
 - The AI Shortcut Audit section is intended to grow. When a real session surfaces a new shortcut that produced cost, add
   the entry with a route to the doc that would have prevented it. Speculative entries are not added.
+
+## ADR-12: Redaction Scope Is Anti-Drift — "Redact More" Is a Change Against the Founding Contract
+
+**Context:** har-capture's founding contract is to observe and capture everything, scrub PII, and compress so the user
+can submit. Sanitization exists to serve that contract, not to override it — a HAR that survived sanitization must still
+be faithful enough to reconstruct the device's behavior.
+
+Between v0.1 and v0.9 the redactor drifted away from that contract, one locally-defensible change at a time. Two
+instances surfaced together via cable_modem_monitor #163, where a C7000v2 capture could no longer be classified because
+the HAR contained 32× `Authorization: AUTH_<hash>` with no scheme prefix:
+
+1. **Authorization scheme tokens were stripped.** `Basic` / `Bearer` / `Digest` is protocol structure from a closed set
+   of RFC 7235 identifiers — it is not a secret. Removing it did not scrub PII; it destroyed the only signal that let a
+   downstream consumer classify the auth mechanism without a `401 + WWW-Authenticate` exchange.
+1. **Cookie attribute values were clobbered.** The cookie regex `([^=;\s]+)=([^;]*)` matches `Path=/` and `Max-Age=3600`
+   exactly as it matches `session=<secret>`, so protocol metadata was hashed alongside credentials.
+
+Neither was introduced carelessly. Each was a reasonable "redact this too" step viewed on its own. The cost was only
+visible in aggregate, and only from outside the tool — a consumer that could no longer do its job.
+
+**Decision:** Widening redaction scope is a change **against** the founding contract and carries the burden of proof. It
+is not a safety improvement by default.
+
+Three rules follow:
+
+1. **Protocol structure is never PII.** Scheme tokens, cookie attributes, URL path shape and segment count, field names,
+   JSON keys, MIME types, status codes, header names. Redaction replaces *values*; it must not alter the shape a
+   consumer parses. When a value must be redacted in a structural position, the placeholder occupies that position — the
+   structure survives.
+1. **A "redact more" proposal names the concrete leak it closes and the fidelity it costs.** "Safer" is not a rationale.
+   If the fidelity cost cannot be stated, the analysis is incomplete.
+1. **Redaction driven by value shape rather than by label must prove the value cannot be legitimate data.** The bar is
+   *cannot be structure*, not *scores high on entropy*. `GetDeviceInformation` and `configurationSettings` are the
+   canonical counterexamples — both are long, both are opaque to a naive detector, both are URL path segments. They are
+   why `_LONG_TOKEN_PATTERN` requires mixed letters *and* digits at 32+ characters.
+
+**Relationship to invariant 11:** [`SANITIZATION_SPEC.md`](specs/SANITIZATION_SPEC.md#constraints-invariants) invariant
+11 governs *confidence* — what may auto-redact without user review. This ADR governs *scope* — what is eligible to be
+considered PII at all. A change can clear invariant 11 (100% confident the value is what we think it is) and still fail
+this ADR (the thing we are certain about is protocol structure). Both gates apply.
+
+**Consequence:** Some real secrets remain in captures until the user redacts them at review. That is the accepted trade:
+the two-pass model (ADR-6) exists to route exactly these cases to a human, and an over-redacted HAR fails silently in a
+way an under-redacted one does not — the user sees flagged values and decides, but nobody sees fidelity that was
+destroyed before the file left their machine.
+
+This ADR does **not** constrain changes that widen *detection and flagging*. Surfacing more candidates for review costs
+no fidelity; `safe_value_patterns` is the release valve when a shape proves benign.

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -11,7 +11,7 @@ two-pass model (auto-sanitize + interactive review) and the format-preserving ha
 
 | File                                         | Role                                                                               |
 | -------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `src/har_capture/sanitization/har.py`        | HAR-level orchestration (~1350 lines, 27 functions, 8 logical groups)              |
+| `src/har_capture/sanitization/har.py`        | HAR-level orchestration, organized into 9 logical groups                           |
 | `src/har_capture/sanitization/html.py`       | HTML/content engine, multi-pass scanner pipeline                                   |
 | `src/har_capture/sanitization/heuristics.py` | Heuristic engine: entropy analysis, credential prefix, adjacency, domain detectors |
 | `src/har_capture/sanitization/collector.py`  | Redaction/flag collection during sanitization                                      |
@@ -57,7 +57,7 @@ two-pass model (auto-sanitize + interactive review) and the format-preserving ha
 
 ### Logical Groups
 
-The ~1350-line file is organized into 8 groups:
+The file is organized into 9 groups:
 
 1. **HAR Structure Validation** — `validate_har_structure()`, `HarSizeError`, `HarValidationError`
 1. **Pattern Loading** — `_load_sensitive_headers()`, `_load_sensitive_field_patterns()` (module-level caching)
@@ -66,6 +66,7 @@ The ~1350-line file is organized into 8 groups:
 1. **Request Sanitization** — Headers, cookies, POST data (form/JSON), query strings, URL paths
 1. **Response Sanitization** — Headers, cookies, content (MIME-type dispatched)
 1. **Pattern-Based String Sanitization** — 10+ regex patterns for MACs, IPs, emails, SSN, credit cards
+1. **Pass 1b Propagation** — `_is_propagation_eligible()`, `_propagation_search_keys()`, `_propagate_redacted_values()`
 1. **Main Entry Points** — `sanitize_entry()`, `sanitize_har()`, `sanitize_har_file()`
 1. **Pass 2** — `apply_user_redactions()`, `appears_sanitized()`
 
@@ -197,6 +198,9 @@ the HTML engine honors the override end-to-end.
 
 - UUIDs, API keys, long tokens, device serial patterns are flagged (not auto-redacted)
 - Path segments preserved for URL readability
+- A segment that exactly matches a value already redacted elsewhere in the capture is replaced by
+  [Pass 1b](#pass-1b-redacted-value-propagation) after all entries are sanitized — no detection rule is involved, and
+  segment count is preserved
 
 ### JSON Body Traversal
 
@@ -539,10 +543,17 @@ CATEGORY_PREFIX_MAP = {
 
 Per-hasher instance cache (`dict[str, str]`) keyed by `PREFIX:value`:
 
-- Ensures same value always maps to same hash within a session
+- Ensures the same value always maps to the same hash within a session **for a given prefix**
 - Grows unbounded (acceptable for typical HAR sizes)
 - Enables correlation preservation: if `AA:BB:CC:DD:EE:FF` appears in 50 entries, it maps to the same
   `02:xx:xx:xx:xx:xx` every time
+
+The prefix is part of the cache key, so a value redacted on two surfaces under different prefixes receives two different
+placeholders — a session token in a response body becomes `FIELD_<a>` while the same token in an `Authorization` header
+becomes `AUTH_<b>`. Correlation therefore holds within a surface, not across surfaces. This is a property of the current
+design, not a guarantee the spec makes: a reader cannot conclude from a sanitized HAR that `FIELD_<a>` and `AUTH_<b>`
+are the same secret. [Pass 1b](#pass-1b-redacted-value-propagation) is unaffected — it reuses whichever placeholder the
+value was first given, so a propagated copy always matches its source.
 
 ### Static Fallbacks (salt=None)
 
@@ -590,6 +601,73 @@ Metadata embedded via `_embed_sanitization_metadata()`:
   }
 }
 ```
+
+### Pass 1b: Redacted-Value Propagation
+
+A value redacted on one surface can appear verbatim on another that carries no field name to match — most commonly a URL
+path segment (`DELETE /rest/v1/user/3/token/<token>`), where the sanitizer has no label to key on. The strict field-name
+rules never see it, so the same secret ends up redacted in the response body and the `Authorization` header but live in
+the path.
+
+After every entry is sanitized, `sanitize_har` sweeps the whole HAR once and replaces any remaining verbatim occurrence
+of an already-redacted value with the placeholder that value was already assigned.
+
+**This is not a detection rule.** Eligibility is established entirely by the strict rules in Pass 1 — the value is
+already known to be a secret. The only question the sweep answers is whether a textual match elsewhere in the file is
+necessarily the *same* secret rather than a coincidence.
+
+**Eligibility** (`_is_propagation_eligible`) — all four must hold:
+
+| Criterion                                     | Excludes                                                        |
+| --------------------------------------------- | --------------------------------------------------------------- |
+| 16+ characters                                | `0`, `1`, `admin` — replacing these globally would wreck a HAR  |
+| Character set `[A-Za-z0-9._~+/=:-]`, no space | Phrases and values carrying quoting or structural characters    |
+| Contains at least one digit                   | `GetDeviceInformation`, `configurationSettings` — identifiers   |
+| Not `is_safe_value()`                         | IPv6, CIDR, timestamps, versions, already-redacted placeholders |
+
+The digit requirement is the operative form of "must not be word-shaped." Method names, config keys, and API identifiers
+are alphabetic; opaque tokens carry digits. It deliberately excludes all-letter hex (`deadbeefcafebabe`), which falls
+back to review.
+
+**Failing eligibility is not a leak** — it is the pre-existing behavior. The value stays flagged for interactive review,
+and Pass 2 resolves it if the user confirms. That is what allows the bar to be strict: a false negative costs nothing
+beyond the status quo, while a false positive would rewrite unrelated bytes across the file.
+
+Structure is preserved because the substitution is one token for one token: path segment count, query shape, and
+delimiters are untouched.
+
+**Needle expansion and ordering** (`_propagation_search_keys`). Each eligible value contributes two needles — its
+literal form and its percent-encoded form (`quote(value, safe="")`) — both mapping to the same placeholder. A secret
+that had to be escaped to sit in a URL path is otherwise missed entirely, and that would contradict the rule the
+form-urlencoded branch already follows: an encoding difference must not break correlation.
+
+Needles are applied **longest first**. When one redacted value is a prefix of another (a token and a token-plus-suffix),
+replacing the shorter first would substitute inside the longer one and emit a corrupted hybrid — neither placeholder nor
+original, leaking the remaining suffix. Ordering by descending length makes the result independent of which surface the
+sanitizer reached first.
+
+Matching is **exact and case-sensitive**. A copy of a secret that differs only in case is not replaced; case-folding a
+global find-replace would widen collision risk, which is precisely what the eligibility rules exist to constrain.
+
+```python
+def _is_propagation_eligible(value: str) -> bool:
+    """True if a redacted value is safe to replace globally across the HAR."""
+
+def _propagation_search_keys(registry: dict[str, str]) -> list[tuple[str, str]]:
+    """Expand eligible values into (needle, placeholder) pairs, longest needle first."""
+
+def _propagate_redacted_values(har_data: dict, registry: dict[str, str]) -> int:
+    """Replace remaining verbatim occurrences of redacted values. Returns replacement count."""
+```
+
+The registry (`RedactionCollector.redacted_values`) maps original value → assigned placeholder and is populated by
+`_redact_value` on every auto-redaction, so a value keeps the placeholder its first surface gave it. The sweep runs
+before `_embed_sanitization_metadata`, and its replacement count is recorded under the `propagated` category in
+`auto_redacted_counts`.
+
+**Review queue.** A propagated value has no surviving occurrence, so `RedactionCollector.drop_flagged()` withdraws it
+from `report.flagged` — presenting it would ask the user for a decision that cannot change the output. Values that
+failed eligibility, and values that were only ever flagged (never auto-redacted), stay in the queue untouched.
 
 ### URL Credential Location Annotation
 
@@ -727,3 +805,8 @@ Detects common redaction markers to warn users before double-sanitizing.
 1. **Scanner passes require 100% confidence** — Every regex in the HTML scanner pipeline (passes 0–16) auto-redacts
    without user review. A pattern that produces false positives is a bug. Patterns that cannot achieve 100% confidence
    belong in the heuristic engine (flagged for user review), not the scanner pipeline.
+1. **Propagation never widens what counts as a secret** — [Pass 1b](#pass-1b-redacted-value-propagation) only replaces
+   values the strict Pass 1 rules already redacted. It introduces no detection of its own, and a value that fails
+   eligibility keeps the pre-existing behavior (flagged for review). Widening eligibility is a scope change and is
+   governed by
+   [ADR-12](../ARCHITECTURE_DECISIONS.md#adr-12-redaction-scope-is-anti-drift-redact-more-is-a-change-against-the-founding-contract).

--- a/docs/specs/VALIDATION_SPEC.md
+++ b/docs/specs/VALIDATION_SPEC.md
@@ -331,9 +331,9 @@ Playwright writes entries chronologically, so this holds for har-capture's own c
 entries could hide the signal.
 
 Session cookies are matched by name against `session_cookies.name_patterns` in
-[`capture.json`](PATTERN_SPEC.md#capturejson--bloat-extension-filtering-and-session-cookie-names), case-insensitively
-and full-match. Cookie names are read from both the parsed `request.cookies` array and the raw `Cookie` header, since
-HAR producers populate one, the other, or both.
+[`capture.json`](PATTERN_SPEC.md#capturejson-bloat-extension-filtering-and-session-cookie-names), case-insensitively and
+full-match. Cookie names are read from both the parsed `request.cookies` array and the raw `Cookie` header, since HAR
+producers populate one, the other, or both.
 
 **This layer warns only.** It never mutates or rejects a capture — HAR files are immutable evidence. A failure inside
 the check is logged and degrades `completeness` to `None`; it never fails the capture.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.11.0"
+version = "0.11.1"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/sanitization/collector.py
+++ b/src/har_capture/sanitization/collector.py
@@ -35,13 +35,28 @@ class RedactionCollector:
         hasher: The Hasher instance for generating redaction placeholders
         auto_redacted_counts: Counts by category for auto-redacted values
         flagged: List of values flagged for user review
+        redacted_values: Original value -> placeholder, for Pass 1b propagation
         _seen_flagged: Set of values already flagged (for deduplication)
     """
 
     hasher: Hasher
     auto_redacted_counts: dict[str, int] = field(default_factory=dict)
     flagged: list[FlaggedValue] = field(default_factory=list)
+    redacted_values: dict[str, str] = field(default_factory=dict, repr=False)
     _seen_flagged: set[str] = field(default_factory=set, repr=False)
+
+    def record_redacted_value(self, original: str, placeholder: str) -> None:
+        """Remember which placeholder an auto-redacted value was given.
+
+        Feeds the Pass 1b propagation sweep. The first surface to redact a
+        value wins, so the same secret keeps one placeholder everywhere.
+
+        Args:
+            original: The pre-redaction value
+            placeholder: The placeholder that replaced it
+        """
+        if original and original not in self.redacted_values:
+            self.redacted_values[original] = placeholder
 
     def record_auto_redaction(self, category: str) -> None:
         """Record that a value was auto-redacted.
@@ -90,6 +105,23 @@ class RedactionCollector:
                 reason=reason,
             )
         )
+
+    def drop_flagged(self, values: set[str]) -> int:
+        """Remove flagged entries for values that no longer occur in the HAR.
+
+        Used after Pass 1b propagation: a value that was replaced everywhere
+        leaves the user a review decision that cannot change the output.
+
+        Args:
+            values: Original values to withdraw from the review queue
+
+        Returns:
+            Number of flagged entries removed
+        """
+        before = len(self.flagged)
+        self.flagged = [f for f in self.flagged if f.original_value not in values]
+        self._seen_flagged -= values
+        return before - len(self.flagged)
 
     def to_report(self, input_file: str, output_file: str, salt: str) -> SanitizationReport:
         """Create a SanitizationReport from the collected data.

--- a/src/har_capture/sanitization/har.py
+++ b/src/har_capture/sanitization/har.py
@@ -418,9 +418,12 @@ def _redact_value(
     """
     if collector:
         collector.record_auto_redaction(category.lower())
-    if hasher:
-        return hasher.hash_generic(value, category)
-    return REDACTED
+    placeholder = hasher.hash_generic(value, category) if hasher else REDACTED
+    if collector:
+        # Feeds the Pass 1b propagation sweep in sanitize_har. Recorded for every
+        # redaction; eligibility is decided at sweep time by _is_propagation_eligible.
+        collector.record_redacted_value(value, placeholder)
+    return placeholder
 
 
 def is_sensitive_field(field_name: str) -> bool:
@@ -1583,6 +1586,116 @@ def _detect_client_side_cookies(entries: list[dict[str, Any]]) -> list[str]:
     return [n for n in request_cookie_names if n not in set_cookie_names]
 
 
+# Pass 1b propagation eligibility. See SANITIZATION_SPEC "Pass 1b: Redacted-Value
+# Propagation". These do not decide whether a value is a secret — Pass 1 already
+# did. They decide whether a textual match elsewhere in the file is necessarily
+# the same secret rather than a coincidence.
+_PROPAGATION_MIN_LENGTH = 16
+_PROPAGATION_CHARSET_RE = re.compile(r"^[A-Za-z0-9._~+/=:-]+$")
+_PROPAGATION_DIGIT_RE = re.compile(r"\d")
+
+
+def _is_propagation_eligible(value: str) -> bool:
+    """Check whether a redacted value is safe to replace globally across the HAR.
+
+    Failing this is not a leak — the value keeps the pre-existing behavior and
+    stays flagged for interactive review. That is what lets the bar be strict.
+
+    Args:
+        value: The pre-redaction value
+
+    Returns:
+        True if every textual match of this value must be the same secret
+    """
+    from har_capture.sanitization.heuristics import is_safe_value
+
+    if len(value) < _PROPAGATION_MIN_LENGTH:
+        return False
+    if not _PROPAGATION_CHARSET_RE.match(value):
+        return False
+    # Method names and config keys are alphabetic (GetDeviceInformation); opaque
+    # tokens carry digits. This is the operative form of "must not be word-shaped".
+    if not _PROPAGATION_DIGIT_RE.search(value):
+        return False
+    return not is_safe_value(value)
+
+
+def _propagation_search_keys(registry: dict[str, str]) -> list[tuple[str, str]]:
+    """Expand eligible redacted values into the needles to search for.
+
+    Each value contributes its literal form plus its percent-encoded form, so a
+    secret that had to be escaped to sit in a URL path is still matched. Both
+    map to the same placeholder — an encoding difference must not break
+    correlation, which is the same rule the form-urlencoded branch follows.
+
+    Ordered longest first: when one value is a prefix of another (a token and a
+    token-plus-suffix), replacing the shorter one first would substitute inside
+    the longer one and emit a corrupted hybrid.
+
+    Args:
+        registry: Original value -> placeholder, from RedactionCollector
+
+    Returns:
+        (needle, placeholder) pairs, longest needle first
+    """
+    needles: dict[str, str] = {}
+    for original, placeholder in registry.items():
+        if not _is_propagation_eligible(original):
+            continue
+        needles.setdefault(original, placeholder)
+        encoded = urllib.parse.quote(original, safe="")
+        if encoded != original:
+            needles.setdefault(encoded, placeholder)
+    return sorted(needles.items(), key=lambda item: -len(item[0]))
+
+
+def _propagate_redacted_values(har_data: dict[str, Any], registry: dict[str, str]) -> int:
+    """Replace remaining verbatim occurrences of already-redacted values in-place.
+
+    Substitution is one token for one token, so path segment count, query shape,
+    and delimiters are preserved. Matching is exact and case-sensitive.
+
+    Args:
+        har_data: The sanitized HAR data (mutated in place)
+        registry: Original value -> placeholder, from RedactionCollector
+
+    Returns:
+        Number of occurrences replaced
+    """
+    search_keys = _propagation_search_keys(registry)
+    if not search_keys:
+        return 0
+
+    try:
+        content = json.dumps(har_data)
+    except (TypeError, ValueError) as e:
+        _LOGGER.warning("Propagation skipped, HAR is not serializable: %s", e)
+        return 0
+
+    replacements = 0
+    for needle, placeholder in search_keys:
+        # Escape for JSON string context (quotes, backslashes, control chars),
+        # mirroring apply_user_redactions.
+        escaped_needle = json.dumps(needle)[1:-1]
+        occurrences = content.count(escaped_needle)
+        if occurrences:
+            content = content.replace(escaped_needle, json.dumps(placeholder)[1:-1])
+            replacements += occurrences
+
+    if not replacements:
+        return 0
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as e:
+        _LOGGER.warning("Propagation reverted, HAR did not survive round-trip: %s", e)
+        return 0
+
+    har_data.clear()
+    har_data.update(parsed)
+    return replacements
+
+
 def sanitize_har(
     har_data: dict[str, Any],
     *,
@@ -1714,6 +1827,15 @@ def sanitize_har(
         meta = log.setdefault("_har_capture", {})
         meta["_client_side_cookies"] = client_side
         meta["_sanitized_credentials"] = url_credential_locations
+
+    # Pass 1b: replace values already redacted elsewhere that survived verbatim on
+    # surfaces with no field name to match (most commonly a URL path segment).
+    propagated = _propagate_redacted_values(result, collector.redacted_values)
+    if propagated:
+        collector.auto_redacted_counts["propagated"] = propagated
+        # A propagated value has no surviving occurrence left, so asking the user
+        # to review it is a decision with no effect. Drop it from the review queue.
+        collector.drop_flagged({v for v in collector.redacted_values if _is_propagation_eligible(v)})
 
     # Create report with all collected data
     report = collector.to_report("", "", actual_salt)

--- a/src/har_capture/sanitization/heuristics.py
+++ b/src/har_capture/sanitization/heuristics.py
@@ -82,8 +82,12 @@ SAFE_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^255\.\d+\.\d+\.\d+$"),
     # CIDR notation (with redacted IPs)
     re.compile(r"^(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}$"),
-    # IPv6 addresses (including documentation prefix 2001:db8::)
-    re.compile(r"^[0-9a-f:]+(?:/\d{1,3})?$", re.IGNORECASE),
+    # IPv6 addresses (including documentation prefix 2001:db8::).
+    # The colon is REQUIRED: without the lookahead this matches any all-hex
+    # string, so every session token, MD5, SHA-1 and SHA-256 digest was
+    # classified safe and returned from is_safe_value() before reaching the
+    # entropy check — silently disabling the heuristic layer for hex secrets.
+    re.compile(r"^(?=[^:]*:)[0-9a-f:]+(?:/\d{1,3})?$", re.IGNORECASE),
     # URLs (http/https) — not PII themselves
     re.compile(r"^https?://\S+$"),
     # Common protocol/interface names

--- a/tests/fixtures/test_har.json
+++ b/tests/fixtures/test_har.json
@@ -173,6 +173,24 @@
 
   "xml_post_data_cases": [
     {
+      "id": "namespaced_password_element_redacted",
+      "post_data": {
+        "mimeType": "application/xml",
+        "text": "<ns:request xmlns:ns=\"http://example.invalid/ns\"><ns:password>secret123</ns:password><ns:action>login</ns:action></ns:request>"
+      },
+      "must_not_contain": ["secret123"],
+      "must_contain": ["action"]
+    },
+    {
+      "id": "sensitive_attribute_value_redacted",
+      "post_data": {
+        "mimeType": "application/xml",
+        "text": "<request><field password=\"secret123\" label=\"login\"/></request>"
+      },
+      "must_not_contain": ["secret123"],
+      "must_contain": ["label"]
+    },
+    {
       "id": "text_xml_password_redacted",
       "post_data": {
         "mimeType": "text/xml",
@@ -424,6 +442,53 @@
       ],
       "custom_patterns": {"fields": {"auto_redact_patterns": ["vendorpw", "twofactor"]}},
       "expected_values": {"vendorpw": "[REDACTED]", "twofactor": "[REDACTED]", "user": "admin"}
+    }
+  ],
+  "propagation_eligibility_cases": [
+    {"value": "eba954f1f10817e8f36607c4db106999", "eligible": true, "id": "hex_session_token"},
+    {"value": "5f4dcc3b5aa765d61d8327deb882cf99", "eligible": true, "id": "hex_md5"},
+    {"value": "a1b2c3d4e5f60718", "eligible": true, "id": "hex_exactly_16"},
+    {"value": "dXNlcjpwYXNzd29yZDEyMzQ1Ng==", "eligible": true, "id": "base64_with_padding"},
+    {"value": "abc-123_XYZ.tok~en+9/8=", "eligible": true, "id": "full_permitted_charset"},
+    {"value": "0", "eligible": false, "id": "single_digit_too_short"},
+    {"value": "1", "eligible": false, "id": "one_too_short"},
+    {"value": "admin", "eligible": false, "id": "common_word_too_short"},
+    {"value": "a1b2c3d4e5f6071", "eligible": false, "id": "fifteen_chars_below_floor"},
+    {"value": "GetDeviceInformation", "eligible": false, "id": "api_method_name_no_digit"},
+    {"value": "configurationSettings", "eligible": false, "id": "identifier_no_digit"},
+    {"value": "deadbeefcafebabedeadbeef", "eligible": false, "id": "all_letter_hex_no_digit"},
+    {"value": "2001:db8::8df9:ca89/56", "eligible": false, "id": "ipv6_is_safe_value"},
+    {"value": "correct horse battery1", "eligible": false, "id": "phrase_contains_space"},
+    {"value": "token\"with1quote", "eligible": false, "id": "quote_char_not_permitted"},
+    {"value": "value1&other=2xxxxxxx", "eligible": false, "id": "ampersand_not_permitted"},
+    {"value": "", "eligible": false, "id": "empty_string"}
+  ],
+  "propagation_search_key_cases": [
+    {
+      "id": "plain_value_yields_one_needle",
+      "registry": {"eba954f1f10817e8f36607c4db106999": "FIELD_aaaaaaaa"},
+      "expected_needles": ["eba954f1f10817e8f36607c4db106999"]
+    },
+    {
+      "id": "encodable_value_yields_raw_and_encoded",
+      "registry": {"abc+def/ghi=jkl12345mnop": "FIELD_bbbbbbbb"},
+      "expected_needles": ["abc%2Bdef%2Fghi%3Djkl12345mnop", "abc+def/ghi=jkl12345mnop"]
+    },
+    {
+      "id": "longest_needle_comes_first",
+      "registry": {
+        "eba954f1f10817e8f36607c4db106999": "FIELD_aaaaaaaa",
+        "eba954f1f10817e8f36607c4db106999SUFFIX01": "FIELD_bbbbbbbb"
+      },
+      "expected_needles": [
+        "eba954f1f10817e8f36607c4db106999SUFFIX01",
+        "eba954f1f10817e8f36607c4db106999"
+      ]
+    },
+    {
+      "id": "ineligible_values_produce_no_needles",
+      "registry": {"0": "FIELD_cccccccc", "admin": "FIELD_dddddddd"},
+      "expected_needles": []
     }
   ]
 }

--- a/tests/fixtures/test_heuristics.json
+++ b/tests/fixtures/test_heuristics.json
@@ -92,7 +92,19 @@
     {"value": "HomeNetwork-5G", "is_safe": false, "id": "ssid_like_not_safe"},
     {"value": "Johns-iPhone", "is_safe": false, "id": "device_name_not_safe"},
     {"value": "secretpass123", "is_safe": false, "id": "password_like_not_safe"},
-    {"value": "MyWifi", "is_safe": false, "id": "short_ssid_not_safe"}
+    {"value": "MyWifi", "is_safe": false, "id": "short_ssid_not_safe"},
+    {"value": "eba954f1f10817e8f36607c4db106999", "is_safe": false, "id": "hex_session_token_not_safe"},
+    {"value": "5f4dcc3b5aa765d61d8327deb882cf99", "is_safe": false, "id": "hex_md5_not_safe"},
+    {"value": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "is_safe": false, "id": "hex_sha1_not_safe"},
+    {
+      "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "is_safe": false,
+      "id": "hex_sha256_not_safe"
+    },
+    {"value": "deadbeefcafebabe", "is_safe": false, "id": "hex_no_digits_not_safe"},
+    {"value": "::1", "is_safe": true, "id": "ipv6_loopback"},
+    {"value": "2001:db8::", "is_safe": true, "id": "ipv6_doc_prefix"},
+    {"value": "fe80::a1b2:c3d4:e5f6:7890", "is_safe": true, "id": "ipv6_link_local_full"}
   ],
   "domain_safe_value_cases": [
     {"value": "2.4g", "id": "band_2.4g"},

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import base64
 import json
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -615,6 +616,36 @@ class TestResolveFieldPatterns:
             _resolve_field_patterns({"fields": {"auto_redact_patterns": [f"p{i}"]}})
 
         assert len(_CUSTOM_FIELD_RE_CACHE) == _CUSTOM_FIELD_RE_CACHE_MAX
+
+    def test_header_sets_cache_eviction_bounded_by_max(self) -> None:
+        """The header-sets cache is bounded by the same max as the field cache.
+
+        Both caches share `_CUSTOM_FIELD_RE_CACHE_MAX`; only the field one had
+        an eviction test, so the header cache's bound was unverified.
+        """
+        from har_capture.sanitization.har import (
+            _CUSTOM_FIELD_RE_CACHE_MAX,
+            _CUSTOM_HEADER_SETS_CACHE,
+            _resolve_header_sets,
+        )
+
+        _CUSTOM_HEADER_SETS_CACHE.clear()
+        for i in range(_CUSTOM_FIELD_RE_CACHE_MAX + 5):
+            _resolve_header_sets({"headers": {"full_redact": [f"x-hdr-{i}"]}})
+
+        assert len(_CUSTOM_HEADER_SETS_CACHE) == _CUSTOM_FIELD_RE_CACHE_MAX
+
+    def test_header_sets_cache_returns_cached_instance(self) -> None:
+        """A repeat call with the same patterns must not recompile."""
+        from har_capture.sanitization.har import (
+            _CUSTOM_HEADER_SETS_CACHE,
+            _resolve_header_sets,
+        )
+
+        _CUSTOM_HEADER_SETS_CACHE.clear()
+        patterns = {"headers": {"full_redact": ["x-vendor-token"]}}
+
+        assert _resolve_header_sets(patterns) is _resolve_header_sets(patterns)
 
 
 class TestFieldPatternsScope:
@@ -3875,3 +3906,337 @@ class TestApplicationXmlResponseRouting:
         result = sanitize_entry(entry, salt="test")
         content_text = result["response"]["content"]["text"]
         assert "192.168.1.100" not in content_text
+
+
+# =============================================================================
+# Pass 1b -- Redacted-Value Propagation
+# =============================================================================
+
+# Propagation eligibility: (value, eligible, id)
+PROPAGATION_ELIGIBILITY_CASES = [
+    (c["value"], c["eligible"], c["id"]) for c in _HAR_FIXTURE["propagation_eligibility_cases"]
+]
+
+
+class TestPropagationEligibility:
+    """Tests for _is_propagation_eligible (SANITIZATION_SPEC Pass 1b)."""
+
+    @pytest.mark.parametrize(
+        ("value", "eligible", "desc"),
+        PROPAGATION_ELIGIBILITY_CASES,
+        ids=[c[2] for c in PROPAGATION_ELIGIBILITY_CASES],
+    )
+    def test_eligibility(self, value: str, eligible: bool, desc: str) -> None:
+        """Only values that cannot coincidentally collide are globally replaceable."""
+        from har_capture.sanitization.har import _is_propagation_eligible
+
+        assert _is_propagation_eligible(value) is eligible, (
+            f"{desc}: '{value}' should be {'eligible' if eligible else 'ineligible'}"
+        )
+
+
+def _token_flow_har(token: str, *, path_segment: str | None = None) -> dict:
+    """Build a login -> use -> logout HAR where the token appears on three surfaces."""
+    return {
+        "log": {
+            "version": "1.2",
+            "entries": [
+                {
+                    "request": {
+                        "method": "POST",
+                        "url": "https://10.0.0.1/rest/v1/user/3/token",
+                        "headers": [],
+                    },
+                    "response": {
+                        "status": 200,
+                        "headers": [],
+                        "content": {
+                            "mimeType": "application/json",
+                            "text": json.dumps({"created": {"token": token, "userId": 3}}),
+                        },
+                    },
+                },
+                {
+                    "request": {
+                        "method": "DELETE",
+                        "url": f"https://10.0.0.1/rest/v1/user/3/token/{path_segment or token}",
+                        "headers": [{"name": "Authorization", "value": f"Bearer {token}"}],
+                    },
+                    "response": {
+                        "status": 204,
+                        "headers": [],
+                        "content": {"mimeType": "application/json", "text": ""},
+                    },
+                },
+            ],
+        }
+    }
+
+
+class TestRedactedValuePropagation:
+    """Tests that already-redacted values are replaced on unlabeled surfaces."""
+
+    def test_token_in_url_path_is_redacted(self) -> None:
+        """A token redacted in a body must not survive verbatim in a URL path."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        sanitized, _ = sanitize_har(_token_flow_har(token), salt="test")
+
+        assert token not in json.dumps(sanitized), "token survived somewhere in the HAR"
+
+    def test_url_structure_is_preserved(self) -> None:
+        """Redaction replaces the segment without changing the URL's shape."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        original = _token_flow_har(token)
+        before = original["log"]["entries"][1]["request"]["url"]
+        sanitized, _ = sanitize_har(original, salt="test")
+        after = sanitized["log"]["entries"][1]["request"]["url"]
+
+        assert after.count("/") == before.count("/"), "path segment count changed"
+        assert after.startswith("https://10.0.0.1/rest/v1/user/3/token/")
+
+    def test_propagated_placeholder_matches_original(self) -> None:
+        """The path gets the same placeholder the body was given."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        sanitized, _ = sanitize_har(_token_flow_har(token), salt="test")
+
+        body = json.loads(sanitized["log"]["entries"][0]["response"]["content"]["text"])
+        placeholder = body["created"]["token"]
+        url = sanitized["log"]["entries"][1]["request"]["url"]
+
+        assert url.endswith(f"/{placeholder}"), f"path got a different placeholder than the body: {url}"
+
+    def test_ineligible_value_is_left_alone(self) -> None:
+        """A short redacted value must not be find-replaced across the file."""
+        sanitized, _ = sanitize_har(_token_flow_har("1"), salt="test")
+
+        url = sanitized["log"]["entries"][1]["request"]["url"]
+        assert url == "https://10.0.0.1/rest/v1/user/3/token/1", "short value was propagated"
+        assert "/rest/v1/user/3/" in url, "unrelated digits were rewritten"
+
+    def test_unrelated_path_segments_survive(self) -> None:
+        """Propagation must not touch segments that are not the secret."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        sanitized, _ = sanitize_har(_token_flow_har(token), salt="test")
+
+        for entry in sanitized["log"]["entries"]:
+            assert "/rest/v1/user/3/token" in entry["request"]["url"]
+
+    def test_propagation_count_recorded(self) -> None:
+        """The sweep records what it replaced."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        _, report = sanitize_har(_token_flow_har(token), salt="test")
+
+        assert report.auto_redacted_counts.get("propagated", 0) >= 1
+
+    def test_no_propagation_when_value_absent_elsewhere(self) -> None:
+        """A capture with nothing to propagate is unchanged and records nothing."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        har = _token_flow_har(token, path_segment="somethingelse")
+        sanitized, report = sanitize_har(har, salt="test")
+
+        assert sanitized["log"]["entries"][1]["request"]["url"].endswith("/somethingelse")
+        assert report.auto_redacted_counts.get("propagated", 0) == 0
+
+    def test_propagated_value_leaves_the_review_queue(self) -> None:
+        """A value replaced everywhere is not a decision the user can affect."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        _, report = sanitize_har(_token_flow_har(token), salt="test", heuristics=HeuristicMode.FLAG)
+
+        assert token not in [f.original_value for f in report.flagged]
+
+    def test_unpropagated_flag_stays_in_the_review_queue(self) -> None:
+        """Dropping propagated values must not empty the queue of everything else."""
+        token = "eba954f1f10817e8f36607c4db106999"
+        uuid = "fb75f58f-2821-4c8e-a8e8-b44bd3f9e012"
+        har = _token_flow_har(token)
+        har["log"]["entries"][1]["request"]["url"] = (
+            f"https://10.0.0.1/rest/v1/user/3/token/{token}/session/{uuid}"
+        )
+        sanitized, report = sanitize_har(har, salt="test", heuristics=HeuristicMode.FLAG)
+
+        flagged = [f.original_value for f in report.flagged]
+        assert token not in flagged, "propagated value should have left the queue"
+        assert uuid in flagged, "unrelated flagged value was dropped with it"
+        assert uuid in sanitized["log"]["entries"][1]["request"]["url"], (
+            "a flagged-only value must not be auto-redacted"
+        )
+
+
+class TestPropagationFailureModes:
+    """Pass 1b must degrade to a no-op, never corrupt a HAR (invariant 5)."""
+
+    def test_unserializable_har_is_left_untouched(self) -> None:
+        """A HAR that cannot be serialized skips propagation instead of raising."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        token = "eba954f1f10817e8f36607c4db106999"
+        har = {"log": {"entries": [{"request": {"url": f"/x/{token}"}}]}, "bad": {object()}}
+
+        assert _propagate_redacted_values(har, {token: "FIELD_abc12345"}) == 0
+        assert har["log"]["entries"][0]["request"]["url"] == f"/x/{token}"
+
+    def test_failed_round_trip_reverts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the rewritten HAR does not parse, the original is kept."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        def _raise(*args: object, **kwargs: object) -> None:
+            raise json.JSONDecodeError("boom", "", 0)
+
+        monkeypatch.setattr("har_capture.sanitization.har.json.loads", _raise)
+
+        token = "eba954f1f10817e8f36607c4db106999"
+        har = {"log": {"entries": [{"request": {"url": f"/x/{token}"}}]}}
+
+        assert _propagate_redacted_values(har, {token: "FIELD_abc12345"}) == 0
+        assert har["log"]["entries"][0]["request"]["url"] == f"/x/{token}", "HAR was left half-rewritten"
+
+    def test_empty_registry_is_a_no_op(self) -> None:
+        """Nothing redacted means nothing to sweep."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        har = {"log": {"entries": []}}
+        assert _propagate_redacted_values(har, {}) == 0
+
+
+# Propagation search keys: (registry, expected_needles, id)
+PROPAGATION_SEARCH_KEY_CASES = [
+    (c["registry"], c["expected_needles"], c["id"]) for c in _HAR_FIXTURE["propagation_search_key_cases"]
+]
+
+
+class TestPropagationSearchKeys:
+    """Needle expansion: encoding variants included, longest replaced first."""
+
+    @pytest.mark.parametrize(
+        ("registry", "expected_needles", "desc"),
+        PROPAGATION_SEARCH_KEY_CASES,
+        ids=[c[2] for c in PROPAGATION_SEARCH_KEY_CASES],
+    )
+    def test_search_keys(self, registry: dict, expected_needles: list, desc: str) -> None:
+        """Needles cover each eligible value's encodings, ordered longest first."""
+        from har_capture.sanitization.har import _propagation_search_keys
+
+        assert [needle for needle, _ in _propagation_search_keys(registry)] == expected_needles, desc
+
+    def test_encoded_needle_maps_to_the_same_placeholder(self) -> None:
+        """Raw and percent-encoded forms must resolve to one placeholder."""
+        from har_capture.sanitization.har import _propagation_search_keys
+
+        keys = dict(_propagation_search_keys({"abc+def/ghi=jkl12345mnop": "FIELD_bbbbbbbb"}))
+
+        assert set(keys.values()) == {"FIELD_bbbbbbbb"}
+
+
+class TestPropagationOverlappingValues:
+    """A value that is a prefix of another must not be substituted inside it."""
+
+    OVERLAP_SHORT = "eba954f1f10817e8f36607c4db106999"
+    OVERLAP_LONG = "eba954f1f10817e8f36607c4db106999SUFFIX01"
+
+    @pytest.mark.parametrize(
+        "registry_order",
+        [("short_first"), ("long_first")],
+        ids=["short_registered_first", "long_registered_first"],
+    )
+    def test_longest_match_wins_regardless_of_registry_order(self, registry_order: str) -> None:
+        """Output must not depend on which value the sanitizer reached first."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        pairs = [(self.OVERLAP_SHORT, "FIELD_aaaaaaaa"), (self.OVERLAP_LONG, "FIELD_bbbbbbbb")]
+        if registry_order == "long_first":
+            pairs.reverse()
+
+        har = {"log": {"entries": [{"request": {"url": f"/x/{self.OVERLAP_LONG}"}}]}}
+        _propagate_redacted_values(har, dict(pairs))
+
+        assert har["log"]["entries"][0]["request"]["url"] == "/x/FIELD_bbbbbbbb"
+
+    def test_no_corrupted_hybrid_is_produced(self) -> None:
+        """The suffix must never survive glued onto a placeholder."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        har = {"log": {"entries": [{"request": {"url": f"/x/{self.OVERLAP_LONG}"}}]}}
+        _propagate_redacted_values(
+            har, {self.OVERLAP_SHORT: "FIELD_aaaaaaaa", self.OVERLAP_LONG: "FIELD_bbbbbbbb"}
+        )
+
+        assert "SUFFIX01" not in json.dumps(har), "suffix leaked out of a mangled substitution"
+
+    def test_both_overlapping_values_still_redacted_when_both_present(self) -> None:
+        """Each value keeps its own placeholder when both appear separately."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        har = {
+            "log": {
+                "entries": [
+                    {"request": {"url": f"/a/{self.OVERLAP_SHORT}"}},
+                    {"request": {"url": f"/b/{self.OVERLAP_LONG}"}},
+                ]
+            }
+        }
+        _propagate_redacted_values(
+            har, {self.OVERLAP_SHORT: "FIELD_aaaaaaaa", self.OVERLAP_LONG: "FIELD_bbbbbbbb"}
+        )
+
+        urls = [e["request"]["url"] for e in har["log"]["entries"]]
+        assert urls == ["/a/FIELD_aaaaaaaa", "/b/FIELD_bbbbbbbb"]
+
+
+class TestPropagationEncodedValues:
+    """A secret that is percent-encoded on another surface must still be caught."""
+
+    ENCODABLE = "abc+def/ghi=jkl12345mnop"
+
+    def _flow(self, url_token: str) -> dict:
+        return {
+            "log": {
+                "entries": [
+                    {
+                        "request": {"method": "POST", "url": "https://10.0.0.1/login", "headers": []},
+                        "response": {
+                            "status": 200,
+                            "headers": [],
+                            "content": {
+                                "mimeType": "application/json",
+                                "text": json.dumps({"token": self.ENCODABLE}),
+                            },
+                        },
+                    },
+                    {
+                        "request": {"method": "GET", "url": f"https://10.0.0.1/a/{url_token}", "headers": []},
+                        "response": {
+                            "status": 200,
+                            "headers": [],
+                            "content": {"mimeType": "application/json", "text": "{}"},
+                        },
+                    },
+                ]
+            }
+        }
+
+    def test_percent_encoded_path_segment_is_redacted(self) -> None:
+        """The encoded copy of a redacted secret must not survive."""
+        encoded = urllib.parse.quote(self.ENCODABLE, safe="")
+        sanitized, _ = sanitize_har(self._flow(encoded), salt="test")
+
+        assert encoded not in json.dumps(sanitized)
+        assert self.ENCODABLE not in json.dumps(sanitized)
+
+    def test_encoded_copy_gets_the_same_placeholder_as_the_body(self) -> None:
+        """Encoding difference must not break correlation."""
+        encoded = urllib.parse.quote(self.ENCODABLE, safe="")
+        sanitized, _ = sanitize_har(self._flow(encoded), salt="test")
+
+        placeholder = json.loads(sanitized["log"]["entries"][0]["response"]["content"]["text"])["token"]
+        assert sanitized["log"]["entries"][1]["request"]["url"].endswith(f"/{placeholder}")
+
+    def test_raw_and_encoded_copies_both_replaced(self) -> None:
+        """A capture carrying both forms loses both."""
+        from har_capture.sanitization.har import _propagate_redacted_values
+
+        encoded = urllib.parse.quote(self.ENCODABLE, safe="")
+        har = {"log": {"entries": [{"request": {"url": f"/a/{self.ENCODABLE}/b/{encoded}"}}]}}
+        count = _propagate_redacted_values(har, {self.ENCODABLE: "FIELD_bbbbbbbb"})
+
+        assert har["log"]["entries"][0]["request"]["url"] == "/a/FIELD_bbbbbbbb/b/FIELD_bbbbbbbb"
+        assert count == 2

--- a/tests/test_sanitization/test_heuristics.py
+++ b/tests/test_sanitization/test_heuristics.py
@@ -282,6 +282,10 @@ class TestIsHighEntropy:
         assert low_entropy >= 0
         assert high_entropy <= 6  # Max entropy for ~100 ASCII chars
 
+    def test_entropy_of_empty_string_is_zero(self) -> None:
+        """An empty string has no randomness and must not divide by zero."""
+        assert calculate_entropy("") == 0.0
+
 
 class TestIsAdjacentToRedacted:
     """Tests for adjacency to redacted values."""
@@ -414,6 +418,20 @@ class TestGetConfidenceForValue:
             is_adjacent=is_adjacent,
         )
         assert result == expected
+
+    def test_unknown_detector_confidence_falls_back_to_medium(self) -> None:
+        """A domain file naming a confidence we don't ship must not raise.
+
+        Detector confidence comes from user-supplied JSON, so an unrecognized
+        string is contributor input, not a bug — degrade instead of crashing.
+        """
+        result = get_confidence_for_value(
+            "test-value",
+            detector_confidence="catastrophic",
+            is_entropy=False,
+            is_adjacent=False,
+        )
+        assert result == ConfidenceLevel.MEDIUM
 
 
 class TestRegexDoSPrevention:


### PR DESCRIPTION
**Release target: 0.11.1** (patch — Unreleased carries only `Fixed`)

Closes two sanitization leaks found while investigating a Sagemcom F3896LG-ZG capture.

## Secrets in URL path segments

One session token appeared three times in a real capture. Two were redacted, one was not:

| Location | Before |
| --- | --- |
| Login response body | `FIELD_57d04873` |
| `Authorization: Bearer` | `AUTH_8240d9b2` |
| URL path of the logout call | **left verbatim** |

A path segment carries no field name for the strict rules to match on. Downstream validation did not catch it either — an opaque hex string matches no MAC, IP, or serial pattern, so the capture passed a fixture PII scan while carrying a live-shaped credential.

**Pass 1b** sweeps the whole HAR after every entry is sanitized and replaces any remaining verbatim occurrence of an already-redacted value with the placeholder that value was given.

It adds **no detection of its own**. The value is one the strict rules already redacted; eligibility only answers whether a textual match elsewhere must be the same secret:

- 16+ characters
- charset `[A-Za-z0-9._~+/=:-]`, no whitespace
- contains at least one digit
- not a known-safe shape

The digit requirement keeps `GetDeviceInformation` and `configurationSettings` out — the identifiers that forced `_LONG_TOKEN_PATTERN` into its current shape. The length floor keeps `0` and `admin` from being find-replaced across a file.

Failing eligibility is not a leak — the value keeps today's behavior and stays flagged for review. That is what lets the bar be strict.

Needles also cover the percent-encoded form (so a base64-shaped token escaped into a path is caught) and are applied longest-first (so a value that is a prefix of another cannot be substituted inside it, which would emit a corrupted hybrid). Matching is exact and case-sensitive.

Substitution is one token for one token, so path segment count and URL shape survive.

## Hex-encoded secrets classified as safe

The built-in IPv6 safe-value pattern made its colon optional:

```python
re.compile(r"^[0-9a-f:]+(?:/\d{1,3})?$", re.IGNORECASE)
```

That matches *any* all-hex string. Since the safe-value check is the first gate in `analyze_value()`, every session token, MD5, SHA-1 and SHA-256 digest was skipped before reaching the entropy check, the domain detectors, or adjacency — silently disabling the heuristic layer for hex-shaped secrets wherever it runs (pipe-delimited scanner, web-storage `setItem` scanner).

The pattern now requires a colon. Genuine IPv6 in every form is unaffected, as are colon-bearing channel lists from domain pattern files.

## Governance

**ADR-12** records that widening redaction scope is a change *against* har-capture's founding contract, not a safety improvement by default: protocol structure is never PII, a "redact more" proposal must name the fidelity it costs, and shape-driven redaction must prove the value cannot be legitimate data.

It complements `SANITIZATION_SPEC` invariant 11 — that one governs *confidence*, ADR-12 governs *scope*. A change can clear invariant 11 and still fail ADR-12. New invariant 12 routes future eligibility changes there rather than leaving a constant to be quietly loosened.

## Verification

- 2329 tests pass (was 2311); coverage 95.66% (was 95.39%)
- **Patch coverage 65/65 = 100%** on added source lines; no partial branches in the diff
- 7/7 per-module coverage floors
- `scripts/ci-local.sh` green on the CI matrix profile
- `heuristics.py` 98% → 100%; `har.py` to zero missing statements

Also in this PR, found by auditing the change against the doc tree: four broken doc anchors repaired (one pre-existing in `VALIDATION_SPEC`), `ARCHITECTURE.md` reconciled with the new pass, and the stale line/function counts removed from `SANITIZATION_SPEC` rather than re-pinned, since they drift on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eq5S4Wf6TBxpsm8XkQyYnZ
