### PR TITLE
fix(sanitization): deterministic vendor-serial redaction + validate severity model (0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vendor-format serials now auto-redact — no review required, in every heuristic mode.** CM2500 process-validation
+  round 1 (2026-08-19) ran the contributor instructions verbatim with zero manual interventions: the real modem serial
+  shipped unmasked inside `RouterStatus.htm`'s pipe-delimited `tagValueList` blob. The heuristic engine *had* flagged it
+  at high confidence, but FLAG mode preserves the raw value in the on-disk artifact until the review completes — a
+  skipped review ships the leak. High-confidence `serial_number` detectors (known vendor layouts, e.g. Netgear's 13-char
+  format) are now deterministic: a fullmatch on a delimiter-bounded token is auto-redacted in Pass 1, in HTML, XML, and
+  plain-text content alike — including large firmware JS files the string-pattern length guard skips (`utility.js`
+  carries a `tagValueList` on the CM2500). See ADR-13.
+
+- **`har-capture validate` now catches unlabeled serials — the round-1 leak passed its own confirmation gate.** Every
+  serial pattern in validate required a label (`Serial Number:`, `SN:`, table cells); a bare serial inside a delimited
+  blob was invisible, so the documented "confirms nothing leaked" step blessed the leak. Validate now applies the same
+  high-confidence vendor detectors to the same delimiter-bounded token extraction the sanitizer uses, and reports an
+  unredacted match as an **error** (exit 1) — the two tools can no longer disagree on what counts as a serial.
+
+- **`validate` no longer exits 1 on every healthy capture over `loginName: admin`.** Field-name findings are now tiered
+  like the sanitizer's own patterns: credential names (password, token, secret, ...) stay errors; identity names
+  (username, login, domain, ...) are warnings; and factory-default usernames (`admin`) in identity fields are suppressed
+  entirely — a fixed default is not PII, and a gate that is red on every compliant capture trains contributors to ignore
+  it. `admin` in a *password*-named field is still an error.
+
+- **`validate` cosmetic noise removed.** jquery's `serialize:`/`serializeArray:` methods are no longer reported as
+  potential serial numbers (label patterns now exclude `serialize` and require a digit in the value), and subnet masks
+  (`255.255.255.0`), reserved first octets (255.x, 0.x), and version-string shapes (`1.12.4.5`) are no longer reported
+  as potential public IPs — the sanitizer deliberately preserves all of these.
+
+- **MAC/IP/email scans no longer skip large text bodies.** The string-pattern perf guard skipped any string over 10,000
+  chars, silently exempting real firmware assets (the CM2500's 33 KB `utility.js`) from pattern scanning. The guard now
+  sits at 1 MB — far above any real device asset while still bounding regex cost on pathological bodies.
+
+- **Reviewed artifacts no longer report `user_redacted: 0`.** The embedded sanitization metadata is written at the end
+  of Pass 1, before any review decision exists; applying user redactions now refreshes the `user_redacted` /
+  `user_skipped` counts so the artifact describes itself truthfully (observed on the CM2500 contributor capture).
+
 ## [0.12.0] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-19
+
 ### Fixed
 
 - **Vendor-format serials now auto-redact — no review required, in every heuristic mode.** CM2500 process-validation
@@ -1105,6 +1107,7 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.11.0]: https://github.com/solentlabs/har-capture/compare/v0.10.3...v0.11.0
 [0.11.1]: https://github.com/solentlabs/har-capture/compare/v0.11.0...v0.11.1
 [0.12.0]: https://github.com/solentlabs/har-capture/compare/v0.11.1...v0.12.0
+[0.12.1]: https://github.com/solentlabs/har-capture/compare/v0.12.0...v0.12.1
 [0.2.0]: https://github.com/solentlabs/har-capture/compare/v0.1.2...v0.2.0
 [0.2.1]: https://github.com/solentlabs/har-capture/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/solentlabs/har-capture/compare/v0.2.1...v0.2.2
@@ -1132,4 +1135,4 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
 [0.9.0]: https://github.com/solentlabs/har-capture/compare/v0.8.2...v0.9.0
 [0.9.1]: https://github.com/solentlabs/har-capture/compare/v0.9.0...v0.9.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.12.0...HEAD
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.12.1...HEAD

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -307,3 +307,42 @@ destroyed before the file left their machine.
 
 This ADR does **not** constrain changes that widen *detection and flagging*. Surfacing more candidates for review costs
 no fidelity; `safe_value_patterns` is the release valve when a shape proves benign.
+
+## ADR-13: High-Confidence Vendor Serial Formats Are Deterministic — Auto-Redact and Validate-Error, Delimiter-Aware
+
+**Context:** CM2500 process-validation round 1 (2026-08-19) ran the contributor instructions verbatim with zero manual
+sanitize interventions. The real modem serial shipped unmasked in the sanitized artifact, and `har-capture validate`
+blessed the leak. The Netgear serial lives inside a pipe-delimited blob (`RouterStatus.htm` →
+`var tagValueList = '1.01|V6.01.03|<serial>|…'`) where no label exists for the labeled serial passes to anchor on. The
+heuristic engine *did* detect it (high confidence, pre-selected in the review) — but FLAG mode preserves the raw value
+in the on-disk artifact until the review completes, so a skipped or unfinished review ships the leak, and `validate`'s
+serial patterns all required a label, so the documented "confirms nothing leaked" step confirmed a leak.
+
+**Decision:** A `serial_number` detector declared at **high** confidence in a domain pattern file asserts a known vendor
+serial layout and is treated as deterministic by both tools:
+
+- **Sanitize** auto-redacts a fullmatch on a delimiter-bounded candidate token (`redact_vendor_serials`, HTML engine
+  pass 2e plus the non-HTML text-content path), in every heuristic mode — Pass 1, before any artifact reaches disk.
+- **Validate** reports an unredacted fullmatch on the same token extraction as an **error** (exit 1), from the same
+  detector entries — the two tools cannot disagree because they share one pattern source
+  (`patterns/domains/network_device.json`).
+
+**ADR-12 accounting** (a "redact more" change carries the burden of proof):
+
+- *Concrete leak closed:* the CM2500 round-1 serial — and the whole class of unlabeled vendor serials in delimited
+  firmware blobs, which the two-pass model routes to a human exactly when the human is told no action is needed.
+- *Fidelity cost:* one token replaced by a correlation-preserving `SERIAL_<hash>` placeholder. Segment count, delimiter
+  structure, and cross-entry correlation survive. Serial numbers are squarely the PII the tool exists to scrub — no
+  consumer parses the serial's *value* as structure.
+- *Cannot-be-structure proof:* the Netgear layout (13 uppercase alphanumerics: digit, 1–2 letters, 2–4 digits,
+  alphanumeric tail) is digit-led — identifiers, method names, and protocol keywords are letter-led; pure counters carry
+  no letters; the fullmatch-on-token rule rejects serial-shaped substrings of longer runs (hex, base64, compound
+  identifiers).
+
+**Confidence bar:** declaring `"confidence": "high"` on a `serial_number` detector now *means* deterministic — it is
+invariant 11's 100% bar expressed as data. A layout that cannot meet the bar stays at `medium` (flag for review). The
+generic uppercase-alphanumeric backstop remains `medium` for exactly this reason.
+
+**Consequence:** the review no longer sees vendor-format serials at all (they are redacted before flagging), and a
+contributor who skips the review still ships a serial-clean artifact for every layout the domain file knows. Unknown
+layouts remain where ADR-12 puts them: flagged for the human.

--- a/docs/specs/PATTERN_SPEC.md
+++ b/docs/specs/PATTERN_SPEC.md
@@ -305,7 +305,7 @@ Data-driven heuristic detectors that the core engine executes.
 | Field             | Type       | Required | Description                                                                        |
 | ----------------- | ---------- | -------- | ---------------------------------------------------------------------------------- |
 | `category`        | string     | Yes      | Detection category (wifi_ssid, device_name, serial_number, credential, suspicious) |
-| `confidence`      | string     | Yes      | Default confidence: "low", "medium", "high"                                        |
+| `confidence`      | string     | Yes      | Default confidence: "low", "medium", "high" — see the deterministic rule below     |
 | `min_length`      | int        | Yes      | Minimum string length to consider                                                  |
 | `max_length`      | int        | Yes      | Maximum string length to consider                                                  |
 | `requires_letter` | bool       | Yes      | Must contain alphabetic character                                                  |
@@ -326,6 +326,15 @@ The detection loop in `heuristics.py`:
 1. If `requires_letter`: reject if no alphabetic characters
 1. Run each regex pattern — first match wins, return `(True, reason)`
 1. If `camelcase=True` and no pattern matched: check `^[A-Z][a-z]+[A-Z][a-zA-Z0-9]*$`
+
+**Deterministic rule for `serial_number` @ `high`:** a `serial_number` detector declared at **high** confidence asserts
+a known vendor serial layout and is treated as deterministic, not heuristic
+([ADR-13](../ARCHITECTURE_DECISIONS.md#adr-13-high-confidence-vendor-serial-formats-are-deterministic--auto-redact-and-validate-error-delimiter-aware)):
+the sanitizer auto-redacts a fullmatch on a delimiter-bounded candidate token (`redact_vendor_serials`, using
+`VENDOR_SERIAL_TOKEN_RE` / `high_confidence_serial_detectors` / `match_vendor_serial` from `loader.py`), and
+`har-capture validate` errors on an unredacted match. Declaring `"confidence": "high"` on a `serial_number` detector
+therefore carries the scanner pipeline's 100%-confidence bar — a layout that cannot meet it stays at `medium` (flag for
+review). Other categories at `high` keep the ordinary heuristic meaning (review pre-selection).
 
 ### Section: `tagValueList.safe_values`
 
@@ -390,8 +399,8 @@ The built-in network device domain provides:
 - WiFi SSID detector (band suffixes, common prefixes, CamelCase)
 - Device name detector (possessives, router brands, consumer devices)
 - Serial number detectors, split by confidence: known vendor layouts (13-char Netgear formats — issue #49 C7000v2,
-  CM2500 7S-prefix) at **high** so the review pre-selects them, plus a generic uppercase-alphanumeric backstop at
-  **medium**
+  CM2500 7S-prefix) at **high**, making them deterministic (auto-redacted by the sanitizer, error-level in validate —
+  see the deterministic rule above), plus a generic uppercase-alphanumeric backstop at **medium** (flag for review)
 - Domain-specific safe values for DOCSIS/cable modem vocabulary
 
 ## Merge Order
@@ -464,6 +473,12 @@ def get_session_cookie_patterns(custom_path: Path | str | None = None) -> list[s
 
 # Compile heuristic detectors from sensitive patterns
 def compile_detectors(sensitive: dict) -> list[CompiledDetector]:
+
+# Filter to deterministic vendor serial detectors (serial_number @ high)
+def high_confidence_serial_detectors(detectors: list[CompiledDetector]) -> list[CompiledDetector]:
+
+# Fullmatch a delimiter-bounded candidate token against vendor serial detectors
+def match_vendor_serial(token: str, detectors: list[CompiledDetector]) -> str | None:
 
 # Compile safe value patterns from sensitive patterns
 def compile_safe_value_patterns(sensitive: dict) -> list[re.Pattern]:

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -231,7 +231,10 @@ MIME-type based routing (after the decode-first check):
 
 - `text/html`, `text/xml`, `application/xml` → `sanitize_html()` from html.py
 - `application/json`, `text/json` → `_sanitize_json_recursive()`
-- Other `text/*` → `_sanitize_string_patterns()`
+- Other `text/*` → `_sanitize_string_patterns()` (perf length guard: strings over 1 MB are skipped — the guard sat at
+  10,000 chars until 2026-08-19, silently exempting the CM2500's 33 KB `utility.js` from MAC/IP/email scans), then
+  `redact_vendor_serials()` (delimiter-aware vendor serials — applied outside the length guard so serial coverage never
+  depends on body size)
 - Binary content → skipped
 
 ### String Pattern Sanitization
@@ -278,6 +281,7 @@ The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 
 | 2b   | Serial numbers (table)        | `<td>Label\b</td><td>VALUE</td>`                    | `hasher.hash_value(val, "SERIAL")`     |
 | 2c   | JS serial variables           | Names with serial+Number/Num/No or ending in serial | `hasher.hash_value(val, "SERIAL")`     |
 | 2d   | WPS / pairing / default PINs  | Known PIN label + 8-digit value (issue #47)         | `hasher.hash_value(val, "PIN")`        |
+| 2e   | Vendor-format serials         | High-confidence serial_number detectors, per token  | `hasher.hash_value(val, "SERIAL")`     |
 | 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value     | `hasher.hash_value(val, "ACCOUNT")`    |
 | 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)             | `hasher.hash_ip(ip, is_private=True)`  |
 | 5    | Public IPs                    | Non-private, non-reserved                           | `hasher.hash_ip(ip, is_private=False)` |
@@ -299,6 +303,20 @@ The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 
 **Pass 2c precision rule:** Matches variable names containing the compound `serial` + `number`/`num`/`no` (with optional
 separator), and names ending with `serial`. Does NOT match `serial` followed by unrelated suffixes (`Protocol`, `Port`,
 `Baud`, `ization`). Bare `serial` is excluded — too ambiguous for auto-redact.
+
+**Pass 2e — delimiter-aware vendor serials** (`redact_vendor_serials`): applies the **high-confidence** `serial_number`
+detectors from the loaded domain patterns (known vendor serial layouts, e.g. the Netgear 13-char format) to
+delimiter-bounded candidate tokens (`VENDOR_SERIAL_TOKEN_RE` in `patterns/loader.py`) anywhere in the content. A
+fullmatch auto-redacts as `SERIAL_<hash>` — in **every** heuristic mode, since this is what covers a serial with no
+label at all: the CM2500 round-1 leak was the serial inside `RouterStatus.htm`'s `tagValueList` blob, where FLAG-mode
+review was the only barrier and a skipped review shipped the raw value. The token extraction is the boundary guard: a
+serial-shaped substring of a longer identifier, hex run, or base64 blob is never a candidate. The same helper runs for
+non-HTML text content in `_sanitize_response_content` (Netgear also serves pipe-delimited blobs from `.js` files),
+deliberately **outside** `_sanitize_string_patterns`' perf length guard, so serial coverage never depends on body size.
+`har-capture validate` applies the same detectors to the same token extraction and errors on an unredacted match — see
+[VALIDATION_SPEC](VALIDATION_SPEC.md#check_contentcontent-location-findings-custom_patterns--has_sanitized_url_credential-serial_detectors)
+and
+[ADR-13](../ARCHITECTURE_DECISIONS.md#adr-13-high-confidence-vendor-serial-formats-are-deterministic--auto-redact-and-validate-error-delimiter-aware).
 
 **Sibling-element rule (passes 2, 2b, 2d):** The tag chain between a label and its value — `(?:<[^>]*>\s*)*` — permits
 whitespace between tags, so label/value pairs rendered in sibling elements match (e.g. Technicolor .jst on the XB6/XB7/
@@ -787,6 +805,9 @@ Entry point: `apply_user_redactions(report)`
    - JSON-escape both original and redacted values
    - Global find-and-replace in serialized HAR text
 1. Parse HAR back from JSON
+1. Refresh the embedded metadata's `user_redacted` / `user_skipped` counts — the metadata was embedded at the end of
+   Pass 1, before any review decision existed, so a reviewed artifact would otherwise report `user_redacted: 0` forever
+   (observed on the CM2500 contributor capture, 2026-08-19)
 1. Return modified data
 
 **Compressed-artifact regeneration:** the CLI wrapper (`apply_reviewed_redactions`, `cli/interactive.py`) rewrites the

--- a/docs/specs/VALIDATION_SPEC.md
+++ b/docs/specs/VALIDATION_SPEC.md
@@ -4,8 +4,8 @@
 
 This spec describes the post-sanitization validation pipeline that checks HAR files for PII that survived sanitization.
 It covers what `secrets.py` checks, the difference between the `validate` CLI command and the pre-commit hook usage, how
-`_sensitive_fields` and `_depth` parameters work in `check_json_fields`, and the relationship between validation
-patterns and sanitization patterns.
+`_field_tiers` and `_depth` parameters work in `check_json_fields`, and the relationship between validation patterns and
+sanitization patterns.
 
 It also covers **capture-completeness validation** (`completeness.py`), a second, independent axis: `secrets.py` asks
 "did something leak *into* this file?" while `completeness.py` asks "is the evidence that should be here *missing*?"
@@ -29,16 +29,16 @@ Both run over any HAR regardless of origin.
 The validation module and sanitization module use overlapping pattern sources but serve fundamentally different
 purposes:
 
-| Aspect              | Validation (`secrets.py`)                      | Sanitization (`har.py`)                     |
-| ------------------- | ---------------------------------------------- | ------------------------------------------- |
-| **Purpose**         | Detect PII that wasn't redacted                | Remove PII from HAR files                   |
-| **Action**          | Report findings; block commit                  | Replace values with hashes/placeholders     |
-| **Trigger**         | Pre-commit hook or `validate` CLI              | `sanitize` CLI or `get` capture             |
-| **Scope**           | Field names + header names + formats + content | Field values + response content             |
-| **Pattern sources** | sensitive.json + hard-coded regexes            | pii.json + sensitive.json + domain          |
-| **Heuristics**      | None — pattern-based only                      | Full engine (entropy, detectors, adjacency) |
-| **Correlation**     | N/A                                            | Preserves via salted hashing                |
-| **Output**          | `list[Finding]`                                | Sanitized HAR + `SanitizationReport`        |
+| Aspect              | Validation (`secrets.py`)                                                                             | Sanitization (`har.py`)                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Purpose**         | Detect PII that wasn't redacted                                                                       | Remove PII from HAR files                   |
+| **Action**          | Report findings; block commit                                                                         | Replace values with hashes/placeholders     |
+| **Trigger**         | Pre-commit hook or `validate` CLI                                                                     | `sanitize` CLI or `get` capture             |
+| **Scope**           | Field names + header names + formats + content                                                        | Field values + response content             |
+| **Pattern sources** | sensitive.json + domain serial detectors + hard-coded regexes                                         | pii.json + sensitive.json + domain          |
+| **Heuristics**      | None — pattern-based only (shared vendor-serial detectors are deterministic patterns, not heuristics) | Full engine (entropy, detectors, adjacency) |
+| **Correlation**     | N/A                                                                                                   | Preserves via salted hashing                |
+| **Output**          | `list[Finding]`                                                                                       | Sanitized HAR + `SanitizationReport`        |
 
 **Interaction between the two:**
 
@@ -62,9 +62,20 @@ class Finding:
 
 Severity levels:
 
-- **error**: High-confidence PII leak — should block commit (sensitive headers, base64 credentials, auto-redact field
-  patterns)
-- **warning**: Lower confidence — informational (MAC addresses in content, serial numbers, public IPs)
+- **error**: High-confidence PII leak — should block commit (sensitive headers, base64 credentials, **auto-redact-tier**
+  field names like password/token/secret, vendor-format serial numbers)
+- **warning**: Lower confidence — informational (MAC addresses in content, label-anchored serial candidates, public IPs,
+  **flag-tier** field names like username/login/domain)
+
+**Field-name severity model.** Field-name findings follow the same two tiers the sanitizer uses
+(`sensitive.json fields`): a name matching `auto_redact_patterns` asserts a credential — an unredacted value is an
+**error**; a name matching `flag_patterns` asserts identity-adjacent content the sanitizer itself only flags for review
+— an unredacted value is a **warning**. A flag-tier field whose value is a factory-default username
+(`KNOWN_DEFAULT_USERNAMES`, currently `admin`) is **suppressed entirely**: the value is fixed per device family and
+carries no identifying content, and a gate that is red on every healthy capture trains contributors to ignore it (CM2500
+round 1: three `[ERROR]` on `loginName: admin` exited 1 on a compliant capture). Suppression never applies to
+auto-redact-tier names — `admin` in a password field is a real credential leak. The model applies uniformly to form
+params, urlencoded bodies, JSON fields, and XML elements/attributes via `_classify_field_finding`.
 
 ## Entry Point
 
@@ -132,7 +143,9 @@ Checks form field names and JSON body content:
 
 **Form params** (`postData.params`):
 
-1. For each parameter, check `name` against `auto_redact_patterns` and `flag_patterns`
+1. For each parameter, classify `name` via `_classify_field_finding` (see the
+   [field-name severity model](#finding-dataclass)): `auto_redact_patterns` match → **error**, `flag_patterns` match →
+   **warning**, flag-tier match with a factory-default username value → suppressed
 1. If matched, check if `value` is already redacted
 1. Report if value is not redacted
 1. If the name did NOT match but the form is **login-shaped** (any parameter name in the form matches a sensitive
@@ -162,9 +175,10 @@ Checks form field names and JSON body content:
    carries a real credential)
 1. Malformed XML is caught and skipped (no findings, no crash)
 
-Severity: **error**
+Severity: **tiered** — error for auto-redact-tier names, warning for flag-tier names, factory-default usernames in
+flag-tier fields suppressed. The same model applies to every branch above (form params, urlencoded body, JSON, XML).
 
-### `check_content(content, location, findings, custom_patterns, *, has_sanitized_url_credential)`
+### `check_content(content, location, findings, custom_patterns, *, has_sanitized_url_credential, serial_detectors)`
 
 Detects PII patterns in response content text:
 
@@ -185,18 +199,36 @@ Severity: **error**
 - Skips common test patterns (e.g., `AA:BB:CC:DD:EE:FF`)
 - Checks via `is_redacted()` before reporting
 
-**Serial numbers:**
+**Serial numbers (label-anchored, warning):**
 
 - Pattern: `SN|S/N|Serial Number|SerialNum` + value — inline, in HTML table cells, or in sibling elements (tag chains
   tolerate whitespace between tags, per the sibling-element rule in
   [`SANITIZATION_SPEC.md`](SANITIZATION_SPEC.md#scanner-pipeline))
+- The inline label patterns require `(?!ize)` after `serial` (jquery's `serialize:`/`serializeArray:` methods matched as
+  labels) and a digit in the value (`serialize: function` matched `function` as a serial) — both reproduced as cosmetic
+  noise on the CM2500 round-1 validate run
 - Checks via `is_redacted()` before reporting
+
+**Vendor-format serials (delimiter-aware, error):**
+
+- Applies the **high-confidence** `serial_number` detectors from the loaded patterns (`--patterns`; domain knowledge,
+  e.g. the Netgear 13-char layout) to delimiter-bounded candidate tokens (`VENDOR_SERIAL_TOKEN_RE`) — the same detectors
+  and token extraction the sanitizer's `redact_vendor_serials` pass auto-redacts with, so the two tools agree on what
+  counts as a vendor serial
+  ([ADR-13](../ARCHITECTURE_DECISIONS.md#adr-13-high-confidence-vendor-serial-formats-are-deterministic--auto-redact-and-validate-error-delimiter-aware))
+- Exists because a serial inside a pipe-delimited blob (`tagValueList`) has no label for the patterns above to anchor on
+  — CM2500 round 1 shipped the real serial unmasked and `validate` blessed it
+- An unredacted fullmatch is an **error**: a vendor-format match is a known serial layout, not a maybe
+- Each distinct token is reported once per content body; `validate_har` compiles the detectors once per file and passes
+  them via `serial_detectors`
 
 **Public IPs:**
 
 - Non-private IPv4 addresses (excludes 10.x, 172.16-31.x, 192.168.x, localhost)
 - Excludes redacted placeholders (10.255.x.x, 192.0.2.x)
-- Validates via `is_valid_ip_address()` heuristic
+- Excludes netmasks (`is_netmask()`: contiguous-bit masks like 255.255.252.0), reserved first octets (255.x, 0.x), and
+  version-string shapes (via `is_valid_ip_address()`) — the sanitizer preserves all of these, so flagging them put
+  cosmetic noise on every healthy capture (CM2500 round 1: `255.255.255.0` reported as a potential public IP)
 
 **Line numbers:**
 
@@ -204,7 +236,7 @@ Severity: **error**
 
 Severity: **warning**
 
-### `check_json_fields(data, location, findings, path, custom_patterns, _sensitive_fields, _depth)`
+### `check_json_fields(data, location, findings, path, custom_patterns, _field_tiers, _depth)`
 
 Recursively scans JSON structures for sensitive field names.
 
@@ -217,7 +249,7 @@ def check_json_fields(
     findings: list[Finding],
     path: str = "",
     custom_patterns: str | None = None,
-    _sensitive_fields: list[re.Pattern[str]] | None = None,
+    _field_tiers: _FieldTiers | None = None,
     _depth: int = 0,
 ) -> None:
 ```
@@ -234,15 +266,16 @@ def check_json_fields(
 
 #### Internal Parameters
 
-| Parameter           | Type                       | Description                                          |
-| ------------------- | -------------------------- | ---------------------------------------------------- |
-| `_sensitive_fields` | list\[re.Pattern\] \| None | Pre-compiled regex patterns — loaded once, reused    |
-| `_depth`            | int                        | Recursion depth counter — checked against limit (50) |
+| Parameter      | Type                 | Description                                          |
+| -------------- | -------------------- | ---------------------------------------------------- |
+| `_field_tiers` | \_FieldTiers \| None | Pre-compiled tier patterns — loaded once, reused     |
+| `_depth`       | int                  | Recursion depth counter — checked against limit (50) |
 
-**`_sensitive_fields` lifecycle:**
+**`_field_tiers` lifecycle:**
 
-1. On first call (`_sensitive_fields=None`): loaded from `_compile_sensitive_fields(custom_patterns)`
-1. Compilation combines `auto_redact_patterns` + `flag_patterns` from `sensitive.json` (plus custom)
+1. On first call (`_field_tiers=None`): loaded from `_compile_field_tiers(custom_patterns)`
+1. Compilation keeps `auto_redact_patterns` and `flag_patterns` from `sensitive.json` (plus custom) as separate tiers —
+   severity differs by tier (see the field-name severity model)
 1. On recursive calls: passed through explicitly — avoids recompilation per field
 1. Same compiled patterns used for every key in the entire JSON structure
 
@@ -258,27 +291,27 @@ def check_json_fields(
 
 ```python
 def check_json_fields(data, location, findings, path="",
-                      custom_patterns=None, _sensitive_fields=None, _depth=0):
+                      custom_patterns=None, _field_tiers=None, _depth=0):
     if _depth > 50:
         return
 
-    if _sensitive_fields is None:
-        _sensitive_fields = _compile_sensitive_fields(custom_patterns)
+    if _field_tiers is None:
+        _field_tiers = _compile_field_tiers(custom_patterns)
 
     if isinstance(data, dict):
         for key, value in data.items():
             current_path = f"{path}.{key}" if path else key
-            # Check key against sensitive patterns
-            for pattern in _sensitive_fields:
-                if pattern.search(key):
-                    if not is_redacted(str(value)):
-                        findings.append(Finding(...))
-                    break
+            # Classify key against the field tiers (error / warning / suppressed)
+            if isinstance(value, str) and value and not is_redacted(value):
+                classified = _classify_field_finding(key, value, _field_tiers)
+                if classified is not None:
+                    severity, pattern = classified
+                    findings.append(Finding(severity=severity, ...))
             # Recurse into nested structures
             if isinstance(value, (dict, list)):
                 check_json_fields(value, location, findings, current_path,
                                   custom_patterns,
-                                  _sensitive_fields=_sensitive_fields,
+                                  _field_tiers=_field_tiers,
                                   _depth=_depth + 1)
 
     elif isinstance(data, list):
@@ -286,7 +319,7 @@ def check_json_fields(data, location, findings, path="",
             if isinstance(item, (dict, list)):
                 check_json_fields(item, location, findings, f"{path}[{i}]",
                                   custom_patterns,
-                                  _sensitive_fields=_sensitive_fields,
+                                  _field_tiers=_field_tiers,
                                   _depth=_depth + 1)
 ```
 
@@ -457,6 +490,8 @@ sensitive.json
 │                                           sanitization (is_sensitive_field)
 ├── fields.flag_patterns     → Used by: validation (check_json_fields, check_post_data)
 │                                        sanitization (is_flaggable_field)
+├── heuristics.detectors     → serial_number @ high confidence: validation (check_content vendor-serial scan)
+│   (domain-merged)                        sanitization (redact_vendor_serials); all others: sanitization only
 └── tagValueList.safe_values → Used by: sanitization only (pipe-delimited scanner)
 ```
 
@@ -468,6 +503,7 @@ These patterns are hard-coded in `secrets.py` and not shared with sanitization:
 | ----------------------- | ------------------------------------------- |
 | MAC regex               | Detect unsanitized MACs in response content |
 | Serial regex            | Detect serial numbers in HTML tables        |
+| Netmask check           | Suppress subnet masks in the public-IP scan |
 | IP regex                | Detect public IPs in response content       |
 | Base64 credential check | Detect `user:pass` in URL query params      |
 
@@ -475,12 +511,12 @@ These patterns are hard-coded in `secrets.py` and not shared with sanitization:
 
 These patterns are used only during sanitization:
 
-| Source                                  | Purpose                                                               |
-| --------------------------------------- | --------------------------------------------------------------------- |
-| `pii.json`                              | Full PII detection patterns with replacement prefixes                 |
-| Domain `heuristics.detectors`           | WiFi SSID, device name detection                                      |
-| Domain `heuristics.safe_value_patterns` | Domain-specific safe values                                           |
-| HTML scanner passes                     | Pipe-delimited, password inputs, SSID fields (hardcoded in `html.py`) |
+| Source                                  | Purpose                                                                                                                |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `pii.json`                              | Full PII detection patterns with replacement prefixes                                                                  |
+| Domain `heuristics.detectors`           | WiFi SSID, device name detection (EXCEPT high-confidence serial_number detectors, which validation shares — see above) |
+| Domain `heuristics.safe_value_patterns` | Domain-specific safe values                                                                                            |
+| HTML scanner passes                     | Pipe-delimited, password inputs, SSID fields (hardcoded in `html.py`)                                                  |
 
 ### Design Intent
 
@@ -500,12 +536,14 @@ Validation is intentionally simpler than sanitization:
    the contract between sanitization and validation.
 1. **Depth limit prevents crashes** — `check_json_fields` caps recursion at 50 levels. Exceeding this is logged but does
    not crash or produce findings for deeper content.
-1. **Pattern compilation is done once** — `_sensitive_fields` is compiled on the first call to `check_json_fields` and
-   reused across all recursive invocations and all entries.
+1. **Pattern compilation is done once** — `_field_tiers` is compiled on the first call to `check_json_fields` and reused
+   across all recursive invocations and all entries; `validate_har` compiles the vendor-serial detectors once per file.
 1. **Cookie metadata is distinguished** — Set-Cookie headers containing only attributes (`HttpOnly`, `Secure`,
    `SameSite`) are not flagged. Only headers with actual session values trigger findings.
-1. **Severity is deterministic** — Headers and POST data are always "error"; content patterns are always "warning".
-   There is no confidence scoring in validation (unlike sanitization's heuristic engine).
+1. **Severity is deterministic** — every finding's severity follows from which pattern matched, never from scoring:
+   headers, auto-redact-tier field names, base64 credentials, and vendor-format serials are "error"; flag-tier field
+   names, MAC/label-serial/IP content patterns are "warning"; factory-default usernames in flag-tier fields are
+   suppressed. There is no confidence scoring in validation (unlike sanitization's heuristic engine).
 1. **Empty values are skipped** — Empty header values, empty POST data values, and empty content are not flagged.
 1. **Base64 detection is conservative** — `is_base64_credential()` requires valid base64 characters, successful decode,
    and exactly one colon in the decoded string. Random base64-looking strings that don't decode to `user:pass` format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.12.0"
+version = "0.12.1"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/patterns/domains/network_device.json
+++ b/src/har_capture/patterns/domains/network_device.json
@@ -56,7 +56,7 @@
         "min_length": 13,
         "max_length": 13,
         "requires_letter": true,
-        "_comment": "Known vendor serial layouts get HIGH confidence so the review pre-selects them. Netgear serials are 13 uppercase alphanumerics starting with a digit, then 1-2 letters, then 2-4 digits: 6JT1277YDEAAE (C7000v2, issue #49), 7S02...AAA (CM2500, 2026-08-19 bench session).",
+        "_comment": "HIGH-confidence serial_number detectors are DETERMINISTIC: the sanitizer auto-redacts a fullmatch on a delimiter-bounded token (redact_vendor_serials), and validate errors on an unredacted match. Only declare high when the layout cannot be anything but a serial. Netgear serials are 13 uppercase alphanumerics starting with a digit, then 1-2 letters, then 2-4 digits: 6JT1277YDEAAE (C7000v2, issue #49), 7S02-prefix (CM2500, 2026-08-19 bench session — anchored-only matching let it ship unmasked inside tagValueList).",
         "patterns": [
           {"regex": "^(?=[A-Z0-9]{13}$)[0-9][A-Z]{1,2}[0-9]{2,4}[A-Z0-9]+$", "reason": "Netgear 13-char serial format (issue #49; CM2500 7S-prefix)"}
         ]

--- a/src/har_capture/patterns/loader.py
+++ b/src/har_capture/patterns/loader.py
@@ -627,6 +627,51 @@ def compile_detectors(
     return detectors
 
 
+# Candidate tokens for vendor-format serial matching. A serial embedded in a
+# larger identifier, hex run, or base64 blob must not match, so the token run
+# includes the characters those carriers are made of (\w covers letters,
+# digits, and underscore; the rest are base64/identifier punctuation) — the
+# vendor patterns then reject any token that carries them. Delimiters that
+# bound serials in the wild (pipe, comma, semicolon, quotes, whitespace,
+# colons) all fall outside the class, so a serial inside a delimited blob is
+# extracted as its own token.
+VENDOR_SERIAL_TOKEN_RE: re.Pattern[str] = re.compile(r"[\w.+/=-]+")
+
+
+def high_confidence_serial_detectors(
+    detectors: list[CompiledDetector],
+) -> list[CompiledDetector]:
+    """Filter to the detectors treated as deterministic vendor serial formats.
+
+    A ``serial_number`` detector declared at **high** confidence asserts a
+    known vendor serial layout (e.g., the Netgear 13-char format). These are
+    the patterns both the sanitizer (auto-redact) and ``validate`` (error on
+    an unredacted match) apply to delimiter-bounded candidate tokens.
+    """
+    return [d for d in detectors if d.category == "serial_number" and d.confidence == "high"]
+
+
+def match_vendor_serial(
+    token: str,
+    detectors: list[CompiledDetector],
+) -> str | None:
+    """Return the match reason if ``token`` is a vendor-format serial.
+
+    ``detectors`` must already be filtered via
+    ``high_confidence_serial_detectors``. Returns ``None`` when no detector
+    matches. The token must satisfy a detector's length bounds and fullmatch
+    one of its patterns — partial matches never count, so a serial-shaped
+    substring inside a longer token is rejected.
+    """
+    for det in detectors:
+        if not det.min_length <= len(token) <= det.max_length:
+            continue
+        for pattern, reason in det.patterns:
+            if pattern.fullmatch(token):
+                return reason or "vendor serial format"
+    return None
+
+
 def merge_pattern_files(paths: list[Path]) -> dict[str, Any]:
     """Load and merge multiple pattern files into a single dict.
 

--- a/src/har_capture/sanitization/har.py
+++ b/src/har_capture/sanitization/har.py
@@ -30,7 +30,7 @@ from har_capture.patterns import (
     load_sensitive_patterns,
 )
 from har_capture.sanitization.collector import RedactionCollector
-from har_capture.sanitization.html import is_valid_ip_address, sanitize_html
+from har_capture.sanitization.html import is_valid_ip_address, redact_vendor_serials, sanitize_html
 from har_capture.sanitization.report import ConfidenceLevel
 
 if TYPE_CHECKING:
@@ -393,6 +393,47 @@ def _header_sets_scope(custom_patterns: str | dict[str, Any] | None) -> Iterator
         yield
     finally:
         _HEADER_SETS_CTX.reset(token)
+
+
+# --- Vendor-serial detector per-call resolver ---------------------------------
+#
+# Same resolver/cache shape as the field-pattern and header-set subsystems.
+# Only the high-confidence serial_number detectors are kept — they are the
+# deterministic vendor serial formats that redact_vendor_serials applies to
+# non-HTML text content (the HTML engine compiles its own detector list).
+
+_CUSTOM_SERIAL_DETECTORS_CACHE: OrderedDict[str, list[Any]] = OrderedDict()
+
+
+def _resolve_serial_detectors(
+    custom_patterns: str | dict[str, Any] | None,
+) -> list[Any]:
+    """Resolve the high-confidence serial_number detectors for this call.
+
+    ``custom_patterns=None`` resolves against the built-in sensitive.json,
+    which declares no detectors — vendor serial formats are domain knowledge
+    and arrive via ``--patterns``. Cached per canonical key like the other
+    per-call resolvers.
+    """
+    from har_capture.patterns.loader import compile_detectors, high_confidence_serial_detectors
+
+    if custom_patterns is None:
+        return []
+
+    key = _custom_patterns_cache_key(custom_patterns)
+    if key is not None:
+        cached = _CUSTOM_SERIAL_DETECTORS_CACHE.get(key)
+        if cached is not None:
+            _CUSTOM_SERIAL_DETECTORS_CACHE.move_to_end(key)
+            return cached
+
+    resolved = high_confidence_serial_detectors(compile_detectors(load_sensitive_patterns(custom_patterns)))
+
+    if key is not None:
+        _CUSTOM_SERIAL_DETECTORS_CACHE[key] = resolved
+        while len(_CUSTOM_SERIAL_DETECTORS_CACHE) > _CUSTOM_FIELD_RE_CACHE_MAX:
+            _CUSTOM_SERIAL_DETECTORS_CACHE.popitem(last=False)
+    return resolved
 
 
 # Redaction placeholder - single source of truth
@@ -913,7 +954,10 @@ def _sanitize_string_patterns(
     """
     if not value:
         return value
-    if len(value) > 10000:  # Skip very long strings for performance
+    # Perf guard only — must stay far above real firmware assets, or PII scans
+    # silently skip them. At 10,000 chars this skipped the CM2500's 33 KB
+    # utility.js, leaving MACs/IPs in any large non-HTML text body unscanned.
+    if len(value) > 1_000_000:
         _LOGGER.debug("Skipping pattern sanitization for long string (length=%d)", len(value))
         return value
 
@@ -1308,6 +1352,13 @@ def _sanitize_response_content(
     elif (mime_type.startswith("text/") or not mime_type) and content.get("encoding") != "base64":
         # Fallback: apply pattern-based sanitization to text content
         content["text"] = _sanitize_string_patterns(content["text"], hasher, collector)
+        # Vendor-format serials (delimiter-aware, domain detectors) — runs
+        # outside _sanitize_string_patterns so its perf length guard can
+        # never cost serial coverage, however large the text body.
+        if hasher is not None and collector is not None:
+            serial_detectors = _resolve_serial_detectors(custom_patterns)
+            if serial_detectors:
+                content["text"] = redact_vendor_serials(content["text"], serial_detectors, hasher, collector)
 
 
 def _sanitize_response(
@@ -2049,6 +2100,15 @@ def apply_user_redactions(
         raise HarValidationError(
             f"Failed to parse HAR after applying redactions: {e.msg} at position {e.pos}"
         ) from e
+
+    # Refresh the embedded metadata's user-decision counts. The metadata was
+    # embedded at the end of Pass 1, before any review decision existed, so
+    # without this a reviewed artifact reports user_redacted: 0 forever
+    # (observed on the CM2500 contributor capture, 2026-08-19).
+    sanitization_meta = parsed.get("log", {}).get("_har_capture", {}).get("sanitization")
+    if isinstance(sanitization_meta, dict):
+        sanitization_meta["user_redacted"] = report.total_user_redacted
+        sanitization_meta["user_skipped"] = report.total_user_skipped
 
     return parsed
 

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -147,6 +147,53 @@ def _sanitize_pipe_value(
     return value
 
 
+def redact_vendor_serials(
+    content: str,
+    compiled_detectors: list[Any],
+    hasher: Hasher,
+    collector: RedactionCollector,
+) -> str:
+    """Auto-redact vendor-format serials appearing as standalone tokens.
+
+    Applies the high-confidence ``serial_number`` detectors (known vendor
+    serial layouts, e.g. Netgear's 13-char format) to delimiter-bounded
+    candidate tokens anywhere in ``content``. This is what catches a serial
+    inside a pipe-delimited blob (tagValueList) or a bare JS assignment,
+    where no label exists for the labeled serial passes to anchor on.
+
+    ``har-capture validate`` applies the same detectors to the same token
+    extraction (``validation/secrets.py``) — the two tools must agree on
+    what counts as a vendor serial.
+
+    Args:
+        content: Text to scan (HTML, JS, or other text content)
+        compiled_detectors: Full detector list; filtered internally
+        hasher: Hasher for correlation-preserving redaction
+        collector: Collector recording each redaction
+
+    Returns:
+        Content with vendor-format serial tokens replaced by SERIAL_ hashes
+    """
+    from har_capture.patterns.loader import (
+        VENDOR_SERIAL_TOKEN_RE,
+        high_confidence_serial_detectors,
+        match_vendor_serial,
+    )
+
+    serial_detectors = high_confidence_serial_detectors(compiled_detectors)
+    if not serial_detectors:
+        return content
+
+    def replace_serial_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if match_vendor_serial(token, serial_detectors) is None:
+            return token
+        collector.record_auto_redaction("serial_number")
+        return hasher.hash_generic(token, "SERIAL")
+
+    return VENDOR_SERIAL_TOKEN_RE.sub(replace_serial_token, content)
+
+
 def is_valid_ip_address(value: str) -> bool:
     """Check if dotted-decimal string is a valid IPv4 address (not a version string).
 
@@ -497,6 +544,17 @@ def _sanitize_html_impl(
         html,
         flags=re.IGNORECASE,
     )
+
+    # 2e. Vendor-format serials as standalone tokens — delimiter-aware.
+    # Netgear firmware ships the serial inside pipe-delimited blobs
+    # (RouterStatus.htm tagValueList) where no label exists for passes 2-2c
+    # to anchor on, and FLAG-mode review is the only thing between the raw
+    # serial and the shared artifact (CM2500 round-1 leak, 2026-08-19). A
+    # high-confidence serial_number detector asserts a vendor layout tight
+    # enough for the scanner pipeline's 100%-confidence bar, so those
+    # formats auto-redact here. Token extraction bounds the match at
+    # delimiters; a serial-shaped substring of a longer token never fires.
+    html = redact_vendor_serials(html, compiled_detectors, hasher, collector)
 
     # 3. Account/Subscriber IDs
     def replace_account(match: re.Match[str]) -> str:

--- a/src/har_capture/validation/secrets.py
+++ b/src/har_capture/validation/secrets.py
@@ -6,8 +6,10 @@ Scans HAR files for:
 - MAC addresses (non-anonymized)
 - Serial numbers
 - Real IP addresses (non-private)
+- Vendor-format serial numbers in delimited content (shared detectors with
+  the sanitizer, so the two tools agree on what counts as a serial)
 
-This module has ZERO external dependencies (stdlib only).
+This module has ZERO third-party dependencies (stdlib + har_capture only).
 """
 
 from __future__ import annotations
@@ -22,6 +24,12 @@ from pathlib import Path
 from typing import Any
 
 from har_capture.patterns import load_sensitive_patterns
+from har_capture.patterns.loader import (
+    VENDOR_SERIAL_TOKEN_RE,
+    compile_detectors,
+    high_confidence_serial_detectors,
+    match_vendor_serial,
+)
 from har_capture.patterns.redaction import (
     is_base64_credential,
     is_base64_decodable_text,
@@ -30,6 +38,7 @@ from har_capture.patterns.redaction import (
 from har_capture.patterns.redaction import (
     is_redacted as check_if_redacted,
 )
+from har_capture.sanitization.html import is_valid_ip_address
 from har_capture.validation.completeness import load_har
 
 # Cookie attribute-only values (not actual session data)
@@ -46,9 +55,13 @@ MAC_PATTERN = re.compile(r"([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}")
 # Serial number patterns (manufacturer-specific)
 # Tag chains `(?:<[^>]*>\s*)*` tolerate whitespace between tags so serials whose
 # label and value sit in sibling elements (Technicolor .jst span pairs) are caught.
+# The label-anchored patterns require: `(?!ize)` after `serial` so jquery's
+# `serialize:`/`serializeArray:` methods don't match, and a digit in the value
+# so prose/code words after the label (`serialize: function`) don't match —
+# vendor serials always carry digits.
 SERIAL_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"serial[^:]*:\s*(?:<[^>]*>\s*)*[A-Z0-9]{8,}", re.IGNORECASE),
-    re.compile(r"SN[:\s]+(?:<[^>]*>\s*)*[A-Z0-9]{8,}", re.IGNORECASE),
+    re.compile(r"serial(?!ize)[^:]*:\s*(?:<[^>]*>\s*)*(?=[A-Z0-9]*[0-9])[A-Z0-9]{8,}", re.IGNORECASE),
+    re.compile(r"SN[:\s]+(?:<[^>]*>\s*)*(?=[A-Z0-9]*[0-9])[A-Z0-9]{8,}", re.IGNORECASE),
     # Serial numbers in HTML table cells (label in one td, value in next td)
     re.compile(
         r"(?:Serial\s*Number|SerialNum|SN|S/N)\s*(?:</\w+>\s*)*</td>\s*<td[^>]*>\s*(?:<[^>]*>\s*)*([A-Za-z0-9\-]{8,})",
@@ -58,6 +71,14 @@ SERIAL_PATTERNS: list[re.Pattern[str]] = [
 
 # Public IP pattern (not private ranges)
 IP_PATTERN = re.compile(r"\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b")
+
+# Factory-default usernames shipped fixed on device families. These carry no
+# identifying content — flagging them turns the validate gate red on every
+# healthy capture of that family (CM2500: three [ERROR] on `loginName: admin`),
+# training contributors to ignore the gate. Suppression applies ONLY to
+# flag-tier (identity) field matches; a default string in a password-named
+# field is still a real credential leak and stays an error.
+KNOWN_DEFAULT_USERNAMES: frozenset[str] = frozenset({"admin"})
 
 
 def _load_sensitive_headers(custom_patterns: str | dict[str, Any] | None = None) -> list[str]:
@@ -99,6 +120,22 @@ def _load_sensitive_fields(custom_patterns: str | dict[str, Any] | None = None) 
     return patterns
 
 
+def _compile_serial_detectors(custom_patterns: str | dict[str, Any] | None = None) -> list[Any]:
+    """Compile the high-confidence serial_number detectors for validation.
+
+    These are the deterministic vendor serial formats (domain knowledge,
+    loaded via ``--patterns``) that the sanitizer auto-redacts and validate
+    reports as errors when found unredacted.
+
+    Args:
+        custom_patterns: Optional path to custom patterns file
+
+    Returns:
+        Filtered CompiledDetector list (empty without domain patterns)
+    """
+    return high_confidence_serial_detectors(compile_detectors(load_sensitive_patterns(custom_patterns)))
+
+
 def _compile_sensitive_fields(custom_patterns: str | dict[str, Any] | None = None) -> list[re.Pattern[str]]:
     """Compile sensitive field patterns for efficient matching.
 
@@ -109,6 +146,48 @@ def _compile_sensitive_fields(custom_patterns: str | dict[str, Any] | None = Non
         List of compiled regex patterns (case-insensitive)
     """
     return [re.compile(p, re.IGNORECASE) for p in _load_sensitive_fields(custom_patterns)]
+
+
+@dataclass(frozen=True)
+class _FieldTiers:
+    """Compiled field-name patterns split by tier — severity differs by tier.
+
+    ``auto_redact`` names (password, token, secret, ...) assert a credential
+    with certainty: an unredacted value is an **error**. ``flag`` names
+    (username, login, domain, ...) assert identity-adjacent content the
+    sanitizer itself only flags for review: an unredacted value is a
+    **warning**, and a factory-default username is suppressed entirely
+    (see ``KNOWN_DEFAULT_USERNAMES``).
+    """
+
+    auto_redact: tuple[re.Pattern[str], ...]
+    flag: tuple[re.Pattern[str], ...]
+
+    def all_patterns(self) -> tuple[re.Pattern[str], ...]:
+        return self.auto_redact + self.flag
+
+
+def _compile_field_tiers(custom_patterns: str | dict[str, Any] | None = None) -> _FieldTiers:
+    """Compile the auto-redact and flag field-name tiers separately.
+
+    Args:
+        custom_patterns: Optional path to custom patterns file
+
+    Returns:
+        _FieldTiers with case-insensitive compiled patterns per tier
+    """
+    sensitive = load_sensitive_patterns(custom_patterns)
+    fields = sensitive.get("fields", {})
+    auto: list[str] = fields.get("auto_redact_patterns", [])
+    flag: list[str] = fields.get("flag_patterns", [])
+    # Fallback for legacy format — legacy files predate the tier split, so
+    # their patterns keep the stricter (error) treatment.
+    if not auto and not flag:
+        auto = fields.get("patterns", [])
+    return _FieldTiers(
+        auto_redact=tuple(re.compile(p, re.IGNORECASE) for p in auto),
+        flag=tuple(re.compile(p, re.IGNORECASE) for p in flag),
+    )
 
 
 @dataclass
@@ -197,6 +276,35 @@ def is_private_ip(ip: str) -> bool:
         return True
     # Also allow 0.0.0.0 (redacted)
     return all(o == 0 for o in octets)
+
+
+def is_netmask(ip: str) -> bool:
+    """Check if a dotted-quad value is a subnet mask, not a host address.
+
+    Netmasks (255.255.255.0, 255.255.252.0, ...) appear throughout router
+    status pages and carry no PII, but they pass the public-IP shape check.
+    A valid netmask is a contiguous run of 1-bits followed by 0-bits.
+
+    Args:
+        ip: Dotted-quad string
+
+    Returns:
+        True if the value is a valid netmask (including 0.0.0.0 and
+        255.255.255.255)
+    """
+    parts = ip.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        octets = [int(p) for p in parts]
+    except ValueError:
+        return False
+    if not all(0 <= o <= 255 for o in octets):
+        return False
+    value = (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]
+    # 1...10...0 form: the complement must be a contiguous low-bit run
+    inverted = value ^ 0xFFFFFFFF
+    return (inverted & (inverted + 1)) == 0
 
 
 def truncate(value: str, max_len: int = 40) -> str:
@@ -305,46 +413,75 @@ def check_headers(
                 break
 
 
+def _classify_field_finding(
+    name: str,
+    value: str,
+    tiers: _FieldTiers,
+) -> tuple[str, re.Pattern[str]] | None:
+    """Classify a field name/value against the two field tiers.
+
+    Returns ``(severity, matched_pattern)``, or ``None`` when no finding
+    should be reported. Auto-redact-tier names are errors; flag-tier names
+    are warnings; a flag-tier name whose value is a factory-default username
+    is suppressed (see ``KNOWN_DEFAULT_USERNAMES``).
+    """
+    matched = next((p for p in tiers.auto_redact if p.search(name)), None)
+    if matched:
+        return ("error", matched)
+    matched = next((p for p in tiers.flag if p.search(name)), None)
+    if matched:
+        if value.strip().lower() in KNOWN_DEFAULT_USERNAMES:
+            return None
+        return ("warning", matched)
+    return None
+
+
 def _check_form_params(
     pairs: list[tuple[str, str]],
     location: str,
     findings: list[Finding],
-    sensitive_fields: list[re.Pattern[str]],
+    field_tiers: _FieldTiers,
     custom_patterns: str | dict[str, Any] | None = None,
 ) -> None:
     """Check form name/value pairs for sensitive fields and encoded credentials.
 
-    Sensitive-named fields with unredacted values are errors. In a
-    login-shaped form (any field name matches a sensitive pattern), a
-    base64-decodable value in an unrecognized field is a warning — the
-    backstop for vendor credential fields the patterns don't know yet
-    (the Sercomm/Hitron ``pws`` class, cable_modem_monitor issue #92).
+    Credential-named fields (auto-redact tier) with unredacted values are
+    errors; identity-named fields (flag tier) are warnings, with
+    factory-default usernames suppressed. In a login-shaped form (any field
+    name matches a sensitive pattern), a base64-decodable value in an
+    unrecognized field is a warning — the backstop for vendor credential
+    fields the patterns don't know yet (the Sercomm/Hitron ``pws`` class,
+    cable_modem_monitor issue #92).
 
     Args:
         pairs: Form (name, value) pairs
         location: Location string for findings
         findings: List to append findings to
-        sensitive_fields: Pre-compiled sensitive field patterns
+        field_tiers: Pre-compiled field patterns split by tier
         custom_patterns: Optional path to custom patterns file
     """
-    login_shaped = any(any(p.search(name) for p in sensitive_fields) for name, _ in pairs)
+    all_patterns = field_tiers.all_patterns()
+    login_shaped = any(any(p.search(name) for p in all_patterns) for name, _ in pairs)
 
     for name, value in pairs:
         if not value or is_redacted(value, custom_patterns):
             continue
 
-        matched = next((p for p in sensitive_fields if p.search(name)), None)
-        if matched:
+        classified = _classify_field_finding(name, value, field_tiers)
+        if classified is not None:
+            severity, matched = classified
             findings.append(
                 Finding(
-                    severity="error",
+                    severity=severity,
                     location=location,
                     field=name,
                     value=truncate(value),
                     reason=f"Sensitive form field matching '{matched.pattern}'",
                 )
             )
-        elif login_shaped and is_base64_decodable_text(value):
+        elif (
+            not any(p.search(name) for p in all_patterns) and login_shaped and is_base64_decodable_text(value)
+        ):
             findings.append(
                 Finding(
                     severity="warning",
@@ -373,12 +510,12 @@ def check_post_data(
     if not post_data:
         return
 
-    sensitive_fields = _compile_sensitive_fields(custom_patterns)
+    field_tiers = _compile_field_tiers(custom_patterns)
 
     # Check params (form data)
     params = post_data.get("params", [])
     pairs = [(param.get("name", ""), param.get("value", "")) for param in params]
-    _check_form_params(pairs, location, findings, sensitive_fields, custom_patterns)
+    _check_form_params(pairs, location, findings, field_tiers, custom_patterns)
 
     # Check text (raw body — form-urlencoded, JSON, or XML)
     text = post_data.get("text", "")
@@ -394,7 +531,7 @@ def check_post_data(
                 if "=" in segment:
                     name, _, val = segment.partition("=")
                     text_pairs.append((urllib.parse.unquote_plus(name), urllib.parse.unquote_plus(val)))
-            _check_form_params(text_pairs, location + " (body)", findings, sensitive_fields, custom_patterns)
+            _check_form_params(text_pairs, location + " (body)", findings, field_tiers, custom_patterns)
             return
         try:
             json_data = json.loads(text)
@@ -422,7 +559,7 @@ def _check_xml_fields(
     """
     import xml.etree.ElementTree as ET
 
-    sensitive_fields = _compile_sensitive_fields(custom_patterns)
+    field_tiers = _compile_field_tiers(custom_patterns)
 
     try:
         root = ET.fromstring(text)  # noqa: S314
@@ -437,35 +574,35 @@ def _check_xml_fields(
 
         value = (elem.text or "").strip()
         if value and not is_redacted(value, custom_patterns):
-            for pattern in sensitive_fields:
-                if pattern.search(tag):
-                    findings.append(
-                        Finding(
-                            severity="error",
-                            location=location,
-                            field=tag,
-                            value=truncate(value),
-                            reason=f"Sensitive XML element matching '{pattern.pattern}'",
-                        )
+            classified = _classify_field_finding(tag, value, field_tiers)
+            if classified is not None:
+                severity, pattern = classified
+                findings.append(
+                    Finding(
+                        severity=severity,
+                        location=location,
+                        field=tag,
+                        value=truncate(value),
+                        reason=f"Sensitive XML element matching '{pattern.pattern}'",
                     )
-                    break
+                )
 
         # Check attributes (e.g., <password value="secret"/>)
         for attr_name, attr_value in elem.attrib.items():
             if not attr_value or is_redacted(attr_value, custom_patterns):
                 continue
-            for pattern in sensitive_fields:
-                if pattern.search(attr_name):
-                    findings.append(
-                        Finding(
-                            severity="error",
-                            location=location,
-                            field=attr_name,
-                            value=truncate(attr_value),
-                            reason=f"Sensitive XML attribute matching '{pattern.pattern}'",
-                        )
+            classified = _classify_field_finding(attr_name, attr_value, field_tiers)
+            if classified is not None:
+                severity, pattern = classified
+                findings.append(
+                    Finding(
+                        severity=severity,
+                        location=location,
+                        field=attr_name,
+                        value=truncate(attr_value),
+                        reason=f"Sensitive XML attribute matching '{pattern.pattern}'",
                     )
-                    break
+                )
 
 
 def check_json_fields(
@@ -474,7 +611,7 @@ def check_json_fields(
     findings: list[Finding],
     path: str = "",
     custom_patterns: str | dict[str, Any] | None = None,
-    _sensitive_fields: list[re.Pattern[str]] | None = None,
+    _field_tiers: _FieldTiers | None = None,
     _depth: int = 0,
 ) -> None:
     """Recursively check JSON for sensitive fields.
@@ -485,14 +622,14 @@ def check_json_fields(
         findings: List to append findings to
         path: Current path in the JSON structure
         custom_patterns: Optional path to custom patterns file
-        _sensitive_fields: Pre-compiled sensitive field patterns. Internal use only.
+        _field_tiers: Pre-compiled field patterns split by tier. Internal use only.
         _depth: Current recursion depth. Internal use only.
     """
     if _depth > 50:
         return
 
-    if _sensitive_fields is None:
-        _sensitive_fields = _compile_sensitive_fields(custom_patterns)
+    if _field_tiers is None:
+        _field_tiers = _compile_field_tiers(custom_patterns)
 
     if isinstance(data, dict):
         for key, value in data.items():
@@ -500,18 +637,18 @@ def check_json_fields(
 
             # Skip empty or redacted values
             if isinstance(value, str) and value and not is_redacted(value, custom_patterns):
-                for pattern in _sensitive_fields:
-                    if pattern.search(key):
-                        findings.append(
-                            Finding(
-                                severity="error",
-                                location=location,
-                                field=current_path,
-                                value=truncate(value),
-                                reason=f"Sensitive JSON field matching '{pattern.pattern}'",
-                            )
+                classified = _classify_field_finding(key, value, _field_tiers)
+                if classified is not None:
+                    severity, pattern = classified
+                    findings.append(
+                        Finding(
+                            severity=severity,
+                            location=location,
+                            field=current_path,
+                            value=truncate(value),
+                            reason=f"Sensitive JSON field matching '{pattern.pattern}'",
                         )
-                        break
+                    )
 
             # Recurse
             if isinstance(value, dict | list):
@@ -521,7 +658,7 @@ def check_json_fields(
                     findings,
                     current_path,
                     custom_patterns,
-                    _sensitive_fields=_sensitive_fields,
+                    _field_tiers=_field_tiers,
                     _depth=_depth + 1,
                 )
 
@@ -534,7 +671,7 @@ def check_json_fields(
                     findings,
                     f"{path}[{i}]",
                     custom_patterns,
-                    _sensitive_fields=_sensitive_fields,
+                    _field_tiers=_field_tiers,
                     _depth=_depth + 1,
                 )
 
@@ -546,6 +683,7 @@ def check_content(
     custom_patterns: str | dict[str, Any] | None = None,
     *,
     has_sanitized_url_credential: bool = False,
+    serial_detectors: list[Any] | None = None,
 ) -> None:
     """Check response content for PII patterns.
 
@@ -560,6 +698,10 @@ def check_content(
             those entries' response bodies were already evaluated by the
             sanitizer's server-token preservation heuristic, so re-flagging
             them here would be a false positive.
+        serial_detectors: High-confidence serial_number detectors (from
+            ``high_confidence_serial_detectors``), applied delimiter-aware to
+            candidate tokens. ``None`` compiles them from ``custom_patterns``;
+            ``validate_har`` pre-compiles once per file.
     """
     if not content or is_redacted(content, custom_patterns):
         return
@@ -620,10 +762,49 @@ def check_content(
                     )
                 )
 
-    # Check for public IPs
+    # Vendor-format serials as standalone tokens — delimiter-aware. Mirrors
+    # the sanitizer's redact_vendor_serials pass: the same high-confidence
+    # serial_number detectors applied to the same token extraction, so what
+    # the sanitizer auto-redacts, validate errors on when found unredacted.
+    # (CM2500 round 1: the serial inside RouterStatus.htm's tagValueList had
+    # no label for SERIAL_PATTERNS to anchor on, and validate blessed the
+    # leak.) Severity is error: a vendor-format match is a known serial
+    # layout, not a maybe.
+    if serial_detectors is None:
+        serial_detectors = _compile_serial_detectors(custom_patterns)
+    if serial_detectors:
+        seen_serials: set[str] = set()
+        for token_match in VENDOR_SERIAL_TOKEN_RE.finditer(content):
+            token = token_match.group(0)
+            if token in seen_serials:
+                continue
+            reason = match_vendor_serial(token, serial_detectors)
+            if reason is not None and not is_redacted(token, custom_patterns):
+                seen_serials.add(token)
+                findings.append(
+                    Finding(
+                        severity="error",
+                        location=location,
+                        field="content",
+                        value=truncate(token),
+                        reason=f"Vendor-format serial number ({reason})",
+                    )
+                )
+
+    # Check for public IPs. Netmasks, reserved first octets (255.x broadcast
+    # masks, 0.x), and version-string shapes (per is_valid_ip_address) match
+    # the dotted-quad pattern but are not host addresses — the sanitizer
+    # preserves all of them, so flagging them here puts cosmetic noise on
+    # every healthy capture.
     for match in IP_PATTERN.finditer(content):
         ip = match.group(1)
-        if not is_private_ip(ip) and not is_redacted(ip, custom_patterns):
+        if (
+            not is_private_ip(ip)
+            and not ip.startswith(("255.", "0."))
+            and not is_netmask(ip)
+            and is_valid_ip_address(ip)
+            and not is_redacted(ip, custom_patterns)
+        ):
             findings.append(
                 Finding(
                     severity="warning",
@@ -655,6 +836,9 @@ def validate_har(
     """
     har_path = Path(har_path)
     findings: list[Finding] = []
+
+    # Compiled once per file — check_content applies them per entry.
+    serial_detectors = _compile_serial_detectors(custom_patterns)
 
     har_data = load_har(har_path)
 
@@ -708,6 +892,7 @@ def validate_har(
             findings,
             custom_patterns,
             has_sanitized_url_credential=(i in url_cred_entry_indices),
+            serial_detectors=serial_detectors,
         )
 
     return findings

--- a/tests/fixtures/test_secrets.json
+++ b/tests/fixtures/test_secrets.json
@@ -110,7 +110,9 @@
   ],
   "_truncate_note": "Values _X40_, _X50_, _X37_ are sentinel placeholders expanded at load time to 'x' * N.",
   "check_json_fields_cases": [
-    {"data": {"username": "admin", "password": "secret123"},                        "expected_count": 2, "id": "username_and_password_fields_detected"},
+    {"data": {"username": "operator7", "password": "secret123"},                    "expected_count": 2, "id": "username_and_password_fields_detected"},
+    {"data": {"username": "admin", "password": "secret123"},                        "expected_count": 1, "id": "default_username_suppressed_password_still_error"},
+    {"data": {"loginName": "admin"},                                                "expected_count": 0, "id": "default_username_alone_suppressed"},
     {"data": {"user": {"credentials": {"api_key": "abc123xyz"}}},                   "expected_count": 1, "id": "nested_api_key_field"},
     {"data": {"password": "[REDACTED]"},                                            "expected_count": 0, "id": "redacted_value_ignored"},
     {"data": {"password": ""},                                                      "expected_count": 0, "id": "empty_value_ignored"},
@@ -124,7 +126,49 @@
     {"content": "Device MAC is AA:BB:CC:11:22:33",     "expect_ip": false, "expect_mac": true,  "id": "MAC_address_detected"},
     {"content": "MAC: 00:00:00:00:00:00",              "expect_ip": false, "expect_mac": false, "id": "anonymized_MAC_ignored"},
     {"content": "",                                    "expect_ip": false, "expect_mac": false, "id": "empty_content"},
-    {"content": "[REDACTED]",                          "expect_ip": false, "expect_mac": false, "id": "redacted_content"}
+    {"content": "[REDACTED]",                          "expect_ip": false, "expect_mac": false, "id": "redacted_content"},
+    {"content": "Subnet Mask: 255.255.255.0",          "expect_ip": false, "expect_mac": false, "id": "netmask_slash24_ignored"},
+    {"content": "Mask 255.255.252.0 on wan0",          "expect_ip": false, "expect_mac": false, "id": "netmask_slash22_ignored"},
+    {"content": "Broadcast 255.255.255.255 seen",      "expect_ip": false, "expect_mac": false, "id": "broadcast_mask_ignored"},
+    {"content": "Non-mask 255.0.255.0 stays odd",      "expect_ip": false, "expect_mac": false, "id": "reserved_255_prefix_ignored"},
+    {"content": "jquery version 1.12.4.5 loaded",      "expect_ip": false, "expect_mac": false, "id": "version_string_ignored"},
+    {"content": "DNS at 8.8.8.8 responding",           "expect_ip": true,  "expect_mac": false, "id": "repeated_octet_public_ip_detected"}
+  ],
+  "netmask_cases": [
+    {"ip": "255.255.255.0",   "expected": true,  "id": "slash24"},
+    {"ip": "255.255.252.0",   "expected": true,  "id": "slash22"},
+    {"ip": "255.0.0.0",       "expected": true,  "id": "slash8"},
+    {"ip": "255.255.255.255", "expected": true,  "id": "slash32_broadcast"},
+    {"ip": "0.0.0.0",         "expected": true,  "id": "slash0"},
+    {"ip": "255.0.255.0",     "expected": false, "id": "noncontiguous_bits"},
+    {"ip": "203.0.113.45",    "expected": false, "id": "host_address"},
+    {"ip": "255.255.255",     "expected": false, "id": "three_octets"},
+    {"ip": "255.255.255.256", "expected": false, "id": "octet_out_of_range"},
+    {"ip": "255.255.abc.0",   "expected": false, "id": "non_numeric_octet"}
+  ],
+  "serial_label_fp_cases": [
+    {"content": "jQuery.fn.extend({serialize: function(){}, serializeArray: function(){}});", "expect_serial_warning": false, "id": "jquery_serialize_methods_ignored"},
+    {"content": "serialport: function(){}",              "expect_serial_warning": false, "id": "digitless_value_after_label_ignored"},
+    {"content": "Serial Number: 7ZZ0000FAKE00",          "expect_serial_warning": true,  "id": "labeled_serial_with_digits_detected"},
+    {"content": "SN: ABCD1234EFGH",                      "expect_serial_warning": true,  "id": "sn_label_detected"}
+  ],
+  "vendor_serial_cases": [
+    {"content": "var tagValueList = '1.01|V6.01.03|7ZZ0000FAKE00|1|Denied';", "expected_errors": 1, "id": "serial_in_pipe_blob_is_error"},
+    {"content": "var tagValueList = '1.01|V6.01.03|SERIAL_2c9c9cf9|1';",      "expected_errors": 0, "id": "redacted_placeholder_clean"},
+    {"content": "7ZZ0000FAKE00 7ZZ0000FAKE00 and 7ZZ0000FAKE00",              "expected_errors": 1, "id": "repeated_serial_reported_once"},
+    {"content": "id=x7ZZ0000FAKE00 blob YWJj7ZZ0000FAKE00",                   "expected_errors": 0, "id": "embedded_in_longer_token_ignored"},
+    {"content": "value V6010301AB123 versions 1732584193 uptime",             "expected_errors": 0, "id": "letter_led_and_pure_digit_tokens_ignored"},
+    {"content": "totally serial-free content",                                "expected_errors": 0, "id": "no_candidates"}
+  ],
+  "form_field_severity_cases": [
+    {"name": "loginName",     "value": "admin",         "expected_severity": null,      "id": "default_username_suppressed"},
+    {"name": "loginName",     "value": "ADMIN",         "expected_severity": null,      "id": "default_username_case_insensitive"},
+    {"name": "loginName",     "value": "operator7",     "expected_severity": "warning", "id": "real_username_warns"},
+    {"name": "username",      "value": "kens-router",   "expected_severity": "warning", "id": "username_field_warns"},
+    {"name": "loginPassword", "value": "admin",         "expected_severity": "error",   "id": "default_string_in_password_field_still_error"},
+    {"name": "loginPassword", "value": "hunter2secret", "expected_severity": "error",   "id": "password_field_errors"},
+    {"name": "token",         "value": "abc123def",     "expected_severity": "error",   "id": "token_field_errors"},
+    {"name": "loginName",     "value": "PASS_ab12cd34", "expected_severity": null,      "id": "redacted_value_skipped"}
   ],
   "check_url_cases": [
     {"url": "https://192.168.100.1/status.html?YWRtaW46cGFzc3dvcmQ=", "expected_count": 1, "id": "bare_base64_user_pass"},

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -3962,6 +3962,16 @@ class TestVendorSerialTextContentRouting:
         result = sanitize_entry(entry, salt="test")
         assert "7ZZ0000FAKE00" in result["response"]["content"]["text"]
 
+    def test_no_collector_skips_serial_scan(self) -> None:
+        """Without a collector/hasher the scan is skipped, not crashed."""
+        from har_capture.patterns.loader import resolve_patterns_arg
+        from har_capture.sanitization.har import _sanitize_response_content
+
+        patterns = str(resolve_patterns_arg("network-device"))
+        content = {"mimeType": "text/javascript", "text": "var x = '7ZZ0000FAKE00';"}
+        _sanitize_response_content(content, collector=None, custom_patterns=patterns)
+        assert "7ZZ0000FAKE00" in content["text"]
+
 
 class TestStringPatternLengthGuard:
     """The perf length guard must sit far above real firmware assets.
@@ -4011,6 +4021,19 @@ class TestSerialDetectorResolverCache:
             _resolve_serial_detectors({"_cache_probe": i})
         assert len(_CUSTOM_SERIAL_DETECTORS_CACHE) == _CUSTOM_FIELD_RE_CACHE_MAX
         _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+
+    def test_unserializable_patterns_skip_cache(self) -> None:
+        """A dict with no stable cache key resolves fresh, never cached."""
+        from har_capture.sanitization.har import (
+            _CUSTOM_SERIAL_DETECTORS_CACHE,
+            _resolve_serial_detectors,
+        )
+
+        _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+        # Tuple keys defeat json.dumps, so _custom_patterns_cache_key returns None
+        result = _resolve_serial_detectors({("no", "key"): 1})
+        assert isinstance(result, list)
+        assert len(_CUSTOM_SERIAL_DETECTORS_CACHE) == 0
 
 
 class TestApplicationXmlResponseRouting:

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -3780,6 +3780,48 @@ class TestApplyUserRedactions:
         with pytest.raises(HarValidationError):
             apply_user_redactions("not_a_dict", report)  # type: ignore[arg-type]
 
+    def test_embedded_metadata_user_counts_refreshed(self) -> None:
+        """Pass 2 refreshes the user-decision counts embedded at Pass 1 time.
+
+        The metadata is written before any review decision exists, so a
+        reviewed artifact otherwise reports user_redacted: 0 forever
+        (observed on the CM2500 contributor capture, 2026-08-19).
+        """
+        har_data = {
+            "log": {
+                "_har_capture": {"sanitization": {"user_redacted": 0, "user_skipped": 0}},
+                "entries": [{"request": {"url": "http://test/"}, "response": {"note": "SECRETVAL123"}}],
+            }
+        }
+        report = SanitizationReport(
+            input_file="",
+            output_file="",
+            salt="test",
+            flagged=[
+                FlaggedValue(
+                    original_value="SECRETVAL123",
+                    category="serial_number",
+                    confidence="HIGH",
+                    context="ctx",
+                    reason="test",
+                    status=RedactionStatus.USER_REDACTED,
+                ),
+                FlaggedValue(
+                    original_value="other_value",
+                    category="wifi_ssid",
+                    confidence="LOW",
+                    context="ctx",
+                    reason="test",
+                    status=RedactionStatus.USER_SKIPPED,
+                ),
+            ],
+        )
+        result = apply_user_redactions(har_data, report)
+        meta = result["log"]["_har_capture"]["sanitization"]
+        assert meta["user_redacted"] == 1
+        assert meta["user_skipped"] == 1
+        assert "SECRETVAL123" not in json.dumps(result)
+
     def test_missing_log_raises(self) -> None:
         """Test apply_user_redactions raises when 'log' key missing."""
         report = SanitizationReport(input_file="", output_file="", salt="test")
@@ -3873,6 +3915,72 @@ class TestXmlPostDataSanitization:
             assert forbidden not in text, f"'{forbidden}' should be redacted in {desc}"
         for required in must_contain:
             assert required in text, f"'{required}' should be preserved in {desc}"
+
+
+class TestVendorSerialTextContentRouting:
+    """Vendor-format serials auto-redact in non-HTML text content.
+
+    Netgear pipe-delimited blobs also appear in JS files served as
+    text/javascript (utility.js on the CM2500), which route through the
+    string-pattern fallback, not the HTML engine. The vendor-serial scan
+    runs there too — and outside the string-pattern perf length guard,
+    so serial coverage never depends on body size.
+    """
+
+    def _entry(self, text: str) -> dict:
+        return {
+            "request": {"method": "GET", "url": "http://modem/utility.js", "headers": []},
+            "response": {
+                "status": 200,
+                "headers": [],
+                "content": {"mimeType": "text/javascript", "text": text},
+            },
+        }
+
+    def test_serial_in_js_pipe_blob_redacted(self) -> None:
+        from har_capture.patterns.loader import resolve_patterns_arg
+
+        patterns = str(resolve_patterns_arg("network-device"))
+        entry = self._entry("var tagValueList = 'V6.01.03|7ZZ0000FAKE00|0|retail';")
+        result = sanitize_entry(entry, salt="test", custom_patterns=patterns)
+        content_text = result["response"]["content"]["text"]
+        assert "7ZZ0000FAKE00" not in content_text
+        assert "SERIAL_" in content_text
+
+    def test_serial_redacted_even_in_large_js_file(self) -> None:
+        """The scan is not subject to the string-pattern length guard."""
+        from har_capture.patterns.loader import resolve_patterns_arg
+
+        patterns = str(resolve_patterns_arg("network-device"))
+        big_js = "// filler\n" * 2000 + "var tagValueList = 'V6.01.03|7ZZ0000FAKE00|0';"
+        entry = self._entry(big_js)
+        result = sanitize_entry(entry, salt="test", custom_patterns=patterns)
+        assert "7ZZ0000FAKE00" not in result["response"]["content"]["text"]
+
+    def test_no_domain_patterns_leaves_token(self) -> None:
+        entry = self._entry("var tagValueList = 'V6.01.03|7ZZ0000FAKE00|0';")
+        result = sanitize_entry(entry, salt="test")
+        assert "7ZZ0000FAKE00" in result["response"]["content"]["text"]
+
+
+class TestStringPatternLengthGuard:
+    """The perf length guard must sit far above real firmware assets.
+
+    At 10,000 chars it silently exempted the CM2500's 33 KB utility.js
+    from MAC/IP/email scans; it now guards at 1 MB.
+    """
+
+    def test_macs_redacted_in_firmware_sized_text(self) -> None:
+        """A ~30 KB body — skipped by the old guard — is scanned."""
+        text = "// filler\n" * 3000 + "device 3C:E4:B0:11:22:33 online"
+        result = _sanitize_string_patterns(text)
+        assert "3C:E4:B0:11:22:33" not in result
+
+    def test_over_one_megabyte_still_skipped(self) -> None:
+        """The guard still exists — bodies over 1 MB pass through unscanned."""
+        text = "x" * 1_000_001 + " 3C:E4:B0:11:22:33"
+        result = _sanitize_string_patterns(text)
+        assert "3C:E4:B0:11:22:33" in result
 
 
 class TestApplicationXmlResponseRouting:

--- a/tests/test_sanitization/test_har.py
+++ b/tests/test_sanitization/test_har.py
@@ -3983,6 +3983,36 @@ class TestStringPatternLengthGuard:
         assert "3C:E4:B0:11:22:33" in result
 
 
+class TestSerialDetectorResolverCache:
+    """The per-call serial-detector resolver caches like its sibling resolvers."""
+
+    def test_cache_hit_returns_same_object(self) -> None:
+        from har_capture.sanitization.har import (
+            _CUSTOM_SERIAL_DETECTORS_CACHE,
+            _resolve_serial_detectors,
+        )
+
+        _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+        patterns = {"_cache_probe": "hit"}
+        first = _resolve_serial_detectors(patterns)
+        second = _resolve_serial_detectors(patterns)
+        assert first is second
+        _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+
+    def test_cache_evicts_oldest_at_capacity(self) -> None:
+        from har_capture.sanitization.har import (
+            _CUSTOM_FIELD_RE_CACHE_MAX,
+            _CUSTOM_SERIAL_DETECTORS_CACHE,
+            _resolve_serial_detectors,
+        )
+
+        _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+        for i in range(_CUSTOM_FIELD_RE_CACHE_MAX + 3):
+            _resolve_serial_detectors({"_cache_probe": i})
+        assert len(_CUSTOM_SERIAL_DETECTORS_CACHE) == _CUSTOM_FIELD_RE_CACHE_MAX
+        _CUSTOM_SERIAL_DETECTORS_CACHE.clear()
+
+
 class TestApplicationXmlResponseRouting:
     """Tests that application/xml responses are routed through the HTML engine."""
 

--- a/tests/test_sanitization/test_pipe_delimited.py
+++ b/tests/test_sanitization/test_pipe_delimited.py
@@ -22,8 +22,17 @@ from __future__ import annotations
 
 import pytest
 
+from har_capture.patterns.loader import resolve_patterns_arg
 from har_capture.sanitization.heuristics import analyze_value
 from har_capture.sanitization.html import sanitize_html
+from har_capture.sanitization.report import HeuristicMode
+
+_NETWORK_DEVICE_PATTERNS = str(resolve_patterns_arg("network-device"))
+
+# Synthetic Netgear-shaped serial: 13 uppercase alphanumerics, digit-led,
+# 1-2 letters, 2-4 digits. Never a value from a real capture — and it must
+# not end in XXX, which the allowlist treats as a redaction marker.
+FAKE_NETGEAR_SERIAL = "7ZZ0000FAKE00"
 
 # =============================================================================
 # Test Data - Pipe-Delimited Credential Gaps
@@ -188,6 +197,66 @@ class TestPipeDelimitedCredentialGaps:
         assert should_preserve in result, (
             f"{desc}: value '{should_preserve}' should be preserved but was removed. Result: {result}"
         )
+
+
+class TestVendorSerialAutoRedaction:
+    """Vendor-format serials auto-redact as standalone tokens (pass 2e).
+
+    Regression for the CM2500 round-1 leak (2026-08-19): the Netgear serial
+    inside RouterStatus.htm's tagValueList shipped unmasked because nothing
+    deterministic covered a serial with no label — FLAG-mode review was the
+    only barrier, and a skipped review ships the leak. High-confidence
+    serial_number detectors now auto-redact delimiter-bounded token matches
+    in every heuristic mode.
+    """
+
+    TAG_VALUE_LIST = (
+        f"<html><script>var tagValueList = "
+        f"'1.01|V6.01.03|{FAKE_NETGEAR_SERIAL}|1|Denied|0|1';</script></html>"
+    )
+
+    @pytest.mark.parametrize(
+        "mode",
+        [HeuristicMode.DISABLED, HeuristicMode.FLAG, HeuristicMode.REDACT],
+        ids=["disabled", "flag", "redact"],
+    )
+    def test_serial_in_pipe_blob_auto_redacted_every_mode(self, mode: HeuristicMode) -> None:
+        """The serial must not survive Pass 1 in any mode — review optional."""
+        result = sanitize_html(
+            self.TAG_VALUE_LIST,
+            salt="test-salt",
+            custom_patterns=_NETWORK_DEVICE_PATTERNS,
+            heuristics=mode,
+        )
+        assert FAKE_NETGEAR_SERIAL not in result
+        assert "SERIAL_" in result
+
+    def test_serial_in_bare_js_assignment_auto_redacted(self) -> None:
+        """No pipe blob needed — any delimiter-bounded standalone token matches."""
+        html = f"<script>var sn = '{FAKE_NETGEAR_SERIAL}';</script>"
+        result = sanitize_html(html, salt="test-salt", custom_patterns=_NETWORK_DEVICE_PATTERNS)
+        assert FAKE_NETGEAR_SERIAL not in result
+
+    def test_serial_embedded_in_longer_token_preserved(self) -> None:
+        """A serial-shaped substring of a longer token is not a serial."""
+        html = f"<script>var x = 'prefix{FAKE_NETGEAR_SERIAL}suffix';</script>"
+        result = sanitize_html(html, salt="test-salt", custom_patterns=_NETWORK_DEVICE_PATTERNS)
+        assert FAKE_NETGEAR_SERIAL in result
+
+    def test_without_domain_patterns_no_auto_redaction(self) -> None:
+        """Vendor formats are domain knowledge — base patterns leave the token."""
+        result = sanitize_html(self.TAG_VALUE_LIST, salt="test-salt")
+        assert FAKE_NETGEAR_SERIAL in result
+
+    def test_technical_pipe_values_preserved_alongside_serial(self) -> None:
+        """The auto-redaction touches only the serial token, nothing else."""
+        result = sanitize_html(
+            self.TAG_VALUE_LIST,
+            salt="test-salt",
+            custom_patterns=_NETWORK_DEVICE_PATTERNS,
+        )
+        for kept in ("1.01", "V6.01.03", "Denied"):
+            assert kept in result, f"'{kept}' should be preserved"
 
 
 class TestRealWorldPipeDelimited:

--- a/tests/test_validation/test_secrets.py
+++ b/tests/test_validation/test_secrets.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from har_capture.patterns.loader import resolve_patterns_arg
 from har_capture.validation.secrets import (
     Finding,
     check_content,
@@ -18,6 +19,7 @@ from har_capture.validation.secrets import (
     check_json_fields,
     check_post_data,
     is_cookie_attributes_only,
+    is_netmask,
     is_private_ip,
     is_redacted,
     truncate,
@@ -67,6 +69,22 @@ CHECK_JSON_FIELDS_CASES = [
 CHECK_CONTENT_CASES = [
     (c["content"], c["expect_ip"], c["expect_mac"], c["id"]) for c in _DATA["check_content_cases"]
 ]
+
+NETMASK_CASES = [(c["ip"], c["expected"], c["id"]) for c in _DATA["netmask_cases"]]
+
+SERIAL_LABEL_FP_CASES = [
+    (c["content"], c["expect_serial_warning"], c["id"]) for c in _DATA["serial_label_fp_cases"]
+]
+
+VENDOR_SERIAL_CASES = [(c["content"], c["expected_errors"], c["id"]) for c in _DATA["vendor_serial_cases"]]
+
+FORM_FIELD_SEVERITY_CASES = [
+    (c["name"], c["value"], c["expected_severity"], c["id"]) for c in _DATA["form_field_severity_cases"]
+]
+
+# Vendor-serial detectors are domain knowledge — resolve the built-in
+# network-device domain the way the CLI's --patterns option does.
+_NETWORK_DEVICE_PATTERNS = str(resolve_patterns_arg("network-device"))
 
 # YWRtaW46cGFzcw==  = base64("admin:pass")
 # aGVsbG8gd29ybGQ= = base64("hello world") — no colon, not a credential
@@ -382,6 +400,123 @@ def test_check_content(content: str, expect_ip: bool, expect_mac: bool, desc: st
 
     assert has_ip == expect_ip, f"IP detection failed for {desc}"
     assert has_mac == expect_mac, f"MAC detection failed for {desc}"
+
+
+@pytest.mark.parametrize(
+    ("ip", "expected", "desc"),
+    NETMASK_CASES,
+    ids=[c[2] for c in NETMASK_CASES],
+)
+def test_is_netmask(ip: str, expected: bool, desc: str) -> None:
+    """Test is_netmask() classifies contiguous-bit masks vs host addresses."""
+    assert is_netmask(ip) == expected, f"Failed for {desc}"
+
+
+@pytest.mark.parametrize(
+    ("content", "expect_serial_warning", "desc"),
+    SERIAL_LABEL_FP_CASES,
+    ids=[c[2] for c in SERIAL_LABEL_FP_CASES],
+)
+def test_check_content_serial_label_false_positives(
+    content: str, expect_serial_warning: bool, desc: str
+) -> None:
+    """Labeled serial detection ignores jquery serialize methods and digitless values.
+
+    Regression for CM2500 round-1 validate noise: jquery's ``serialize:``/
+    ``serializeArray:`` methods were reported as potential serial numbers.
+    """
+    findings: list[Finding] = []
+    check_content(content, "response.body", findings)
+    serial_findings = [f for f in findings if f.reason == "Potential serial number"]
+    assert bool(serial_findings) == expect_serial_warning, f"Failed for {desc}: {findings}"
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_errors", "desc"),
+    VENDOR_SERIAL_CASES,
+    ids=[c[2] for c in VENDOR_SERIAL_CASES],
+)
+def test_check_content_vendor_serials(content: str, expected_errors: int, desc: str) -> None:
+    """Delimiter-aware vendor-serial detection with network-device detectors.
+
+    Regression for the CM2500 round-1 leak: a Netgear serial inside a
+    pipe-delimited tagValueList blob has no label for SERIAL_PATTERNS to
+    anchor on, and validate blessed the leak. A vendor-format token match
+    is an error — the same detectors the sanitizer auto-redacts with.
+    """
+    findings: list[Finding] = []
+    check_content(content, "response.body", findings, _NETWORK_DEVICE_PATTERNS)
+    vendor = [f for f in findings if f.reason.startswith("Vendor-format serial")]
+    assert len(vendor) == expected_errors, f"Failed for {desc}: {findings}"
+    assert all(f.severity == "error" for f in vendor), f"{desc}: vendor serials must be errors"
+
+
+def test_check_content_vendor_serials_need_domain_patterns() -> None:
+    """Without domain patterns there are no vendor detectors — no findings."""
+    findings: list[Finding] = []
+    check_content("var tagValueList = '1.01|7ZZ0000FAKE00|1';", "response.body", findings)
+    assert not [f for f in findings if f.reason.startswith("Vendor-format serial")]
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "expected_severity", "desc"),
+    FORM_FIELD_SEVERITY_CASES,
+    ids=[c[3] for c in FORM_FIELD_SEVERITY_CASES],
+)
+def test_form_field_severity_model(name: str, value: str, expected_severity: str | None, desc: str) -> None:
+    """Field-name findings are tiered by pattern tier.
+
+    Credential names error, identity names warn, and factory-default
+    usernames are suppressed (CM2500: loginName=admin exited 1 on every
+    healthy capture, training contributors to ignore the gate).
+    """
+    post_data = {
+        "mimeType": "application/x-www-form-urlencoded",
+        "params": [{"name": name, "value": value}],
+    }
+    findings: list[Finding] = []
+    check_post_data(post_data, "request", findings)
+    field_findings = [f for f in findings if f.field == name]
+    if expected_severity is None:
+        assert not field_findings, f"{desc}: expected no finding, got {field_findings}"
+    else:
+        assert len(field_findings) == 1, f"{desc}: expected one finding, got {findings}"
+        assert field_findings[0].severity == expected_severity, f"{desc}"
+
+
+def test_field_tiers_legacy_format_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A legacy patterns file (single `patterns` list) keeps error treatment."""
+    from har_capture.validation import secrets as secrets_mod
+
+    monkeypatch.setattr(
+        secrets_mod,
+        "load_sensitive_patterns",
+        lambda _cp=None: {"fields": {"patterns": ["password"]}},
+    )
+    tiers = secrets_mod._compile_field_tiers()
+    assert len(tiers.auto_redact) == 1
+    assert not tiers.flag
+
+
+def test_xml_field_severity_model() -> None:
+    """XML element/attribute findings follow the same tier model as form fields."""
+    xml = "<login><username>operator7</username><password>hunter2secret</password><extra loginName='admin'/></login>"
+    post_data = {"mimeType": "text/xml", "text": xml}
+    findings: list[Finding] = []
+    check_post_data(post_data, "request", findings)
+    by_field = {f.field: f.severity for f in findings}
+    assert by_field.get("password") == "error"
+    assert by_field.get("username") == "warning"
+    assert "loginName" not in by_field, "default username in XML attribute must be suppressed"
+
+
+def test_json_field_severity_model() -> None:
+    """JSON field findings follow the same tier model."""
+    findings: list[Finding] = []
+    check_json_fields({"username": "operator7", "password": "hunter2secret"}, "body", findings)
+    by_field = {f.field: f.severity for f in findings}
+    assert by_field.get("password") == "error"
+    assert by_field.get("username") == "warning"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_validation/test_secrets.py
+++ b/tests/test_validation/test_secrets.py
@@ -500,14 +500,17 @@ def test_field_tiers_legacy_format_fallback(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_xml_field_severity_model() -> None:
     """XML element/attribute findings follow the same tier model as form fields."""
-    xml = "<login><username>operator7</username><password>hunter2secret</password><extra loginName='admin'/></login>"
+    xml = (
+        "<login><username>operator7</username><password>hunter2secret</password>"
+        "<loginName>admin</loginName><extra loginName='admin'/></login>"
+    )
     post_data = {"mimeType": "text/xml", "text": xml}
     findings: list[Finding] = []
     check_post_data(post_data, "request", findings)
     by_field = {f.field: f.severity for f in findings}
     assert by_field.get("password") == "error"
     assert by_field.get("username") == "warning"
-    assert "loginName" not in by_field, "default username in XML attribute must be suppressed"
+    assert "loginName" not in by_field, "default username in XML element and attribute must be suppressed"
 
 
 def test_json_field_severity_model() -> None:


### PR DESCRIPTION
## Summary

CM2500 process-validation round 1 (2026-08-19) shipped the real modem serial unmasked inside `RouterStatus.htm`'s pipe-delimited `tagValueList`, and `har-capture validate` blessed the leak. Root cause was **not** the anchored serial regex (the pipe scanner tokenizes before matching and detection flagged the serial at HIGH): FLAG mode leaves the raw value on disk until the interactive review completes, and validate's serial patterns all required a label, with content-serial findings capped at warning severity.

- **ADR-13**: high-confidence `serial_number` detectors are deterministic — sanitize auto-redacts delimiter-bounded token fullmatches in every heuristic mode (HTML pass 2e + text/* branch); validate errors on an unredacted match. Single pattern source in `network_device.json`, so the two tools cannot disagree.
- **validate severity model**: auto-redact-tier field names → error; flag-tier (username/login) → warning; factory-default usernames (`admin`) in flag-tier fields → suppressed. `loginName: admin` no longer exits 1 on every healthy capture.
- **validate cosmetic noise**: jquery `serialize`/`serializeArray` no longer match as serial labels; netmasks, reserved octets (255.x/0.x), and version strings no longer report as public IPs.
- **Pass 2 metadata**: reviewed artifacts no longer report `user_redacted: 0`.
- **String-pattern perf guard raised 10 KB → 1 MB** — it silently exempted the CM2500's 33 KB `utility.js` from MAC/IP/email scans.
- Release prep: version 0.12.1 (all CHANGELOG entries under `Fixed` → patch), specs updated alongside (SANITIZATION/VALIDATION/PATTERN, ADR-13).

## Verification

- 2455 unit tests pass, 95.96% coverage; changed src lines at 100% patch coverage
- Pre-commit clean; pre-push local CI mirror green
- CLI round-trip: raw leaky HAR → `validate` exits 1 naming the serial; non-interactive `sanitize` auto-masks with zero selections; sanitized artifact validates Clean, exit 0
- Fixtures use synthetic serial `7ZZ0000FAKE00` (the suggested `...XXX` form collides with the allowlist redaction-marker pattern)

Bench exit criterion (fresh CM2500 capture, zero manual selection, validate clean) is tracked in the journal task for a later hardware session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ldpuodo7bHUpRH4MrVMsiq