### PR TITLE
fix(sanitization): redact labeled default credentials on the device label block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- **Re-sanitizing a capture no longer rewrites its existing placeholders.** The new structural rules match on markup
-  position rather than value shape, so a placeholder sitting in a value element matches as readily as a credential.
-  Values already recognized as redacted are now left untouched, keeping a fixture sweep idempotent for these passes.
+- **Re-sanitizing a capture no longer rewrites or compounds its placeholders.** Every pass that emits a `PREFIX_<hash>`
+  placeholder now skips values already recognized as redacted, so running `sanitize` over an already-sanitized capture
+  is a byte-level no-op — even under the default random salt. Previously each run re-hashed every placeholder, and
+  serials *grew*: pass 2's value pattern excluded `_`, so it matched only the `SERIAL` prefix of its own output and
+  prepended a fresh hash each time (`SERIAL_9f8e3528_9f8e3528_60ec920f`), without bound. This makes fixture sweeps over
+  sanitized captures produce no spurious diff.
+
+  The format-preserving passes (MAC, IPv4, IPv6, email) deliberately keep their previous behavior and stay
+  non-idempotent. Their placeholders are valid-looking values in reserved ranges and cannot be distinguished from real
+  ones — `02:aa:bb:cc:dd:ee` is a legitimate locally-administered MAC and `10.255.62.183` a legitimate private address.
+  Skipping those to buy cosmetic stability would pass real values through unredacted.
 
 ## [0.12.1] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Security
+
+- **Default Wi-Fi passwords and SSIDs on the device-label block no longer survive sanitization.** Technicolor gateways
+  (XB6/XB7/XB8/XB10) render a "Device Label Information" block on `network_setup.jst` carrying four sticker values in
+  plain text. The serial and WPS PIN were redacted; the default Wi-Fi password and the default SSID survived in
+  **every** heuristic mode, and `har-capture validate` returned 0 errors on a file containing all four — so the step
+  documented as "confirms nothing leaked" blessed a plaintext Wi-Fi credential. A contributor's real Wi-Fi password
+  reached a public GitHub issue this way (cable_modem_monitor#194).
+
+  The cause was neither label vocabulary nor value shape: passes 2/2b/2d carry a tag chain that hops
+  `</span><span class="value">`, and the password/SSID passes never received it — their value patterns stop dead at `<`.
+  New pass 7c matches these by **structural position** instead: the value must occupy its own element. That is what
+  separates a sticker value from gateway help text, which shares a text node with its label. Measured across the
+  committed fleet captures the rule matches the real credential blocks and nothing else. Also covered: SSIDs rendered
+  with no adjacent label at all — in an SSID-named element (`<font class="wifi_ntwrk">`) or as the options of an
+  SSID-named `<select>`. See ADR-14.
+
+- **`har-capture validate` now errors on a labeled plaintext password.** Validation had no label-anchored credential
+  check at all — its password detection was field-name-based (form params, JSON, XML), which HTML text never reaches.
+  The 0.12.1 reconciliation covered vendor serial *tokens* specifically and left this layer divergent. `validate`, the
+  sanitizer, and `check_for_pii` now **import one set of compiled patterns**, so the three cannot drift apart again. A
+  labeled password is an **error** (exit 1); a Wi-Fi network name is a warning.
+
+- **A stray placeholder no longer suppresses an entire response body's content checks.** `check_content` guarded its
+  early return with `is_redacted()`, a single-*value* predicate that matches its allowlist families with `re.search`. A
+  run of six or more zeros (`0{6,}` — a separator-less zero MAC, a zeroed counter, a `#000000` in minified CSS) or a
+  literal `XXX` / `REDACTED` anywhere in a body made the whole page look already-redacted, skipping every content check
+  for that entry — 209 of 750 committed fleet entries were being skipped this way, including a page carrying a plaintext
+  default Wi-Fi password that `validate` therefore reported as clean. The guard now uses `is_fully_redacted()`, which
+  requires the whole string to be one placeholder token: no whitespace, no markup, no structural punctuation, and a
+  match accounting for the entire token rather than merely appearing inside it.
+
+### Fixed
+
+- **Re-sanitizing a capture no longer rewrites its existing placeholders.** The new structural rules match on markup
+  position rather than value shape, so a placeholder sitting in a value element matches as readily as a credential.
+  Values already recognized as redacted are now left untouched, keeping a fixture sweep idempotent for these passes.
+
 ## [0.12.1] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-08-23
+
 ### Security
 
 - **Default Wi-Fi passwords and SSIDs on the device-label block no longer survive sanitization.** Technicolor gateways
@@ -1154,6 +1156,7 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.11.1]: https://github.com/solentlabs/har-capture/compare/v0.11.0...v0.11.1
 [0.12.0]: https://github.com/solentlabs/har-capture/compare/v0.11.1...v0.12.0
 [0.12.1]: https://github.com/solentlabs/har-capture/compare/v0.12.0...v0.12.1
+[0.12.2]: https://github.com/solentlabs/har-capture/compare/v0.12.1...v0.12.2
 [0.2.0]: https://github.com/solentlabs/har-capture/compare/v0.1.2...v0.2.0
 [0.2.1]: https://github.com/solentlabs/har-capture/compare/v0.2.0...v0.2.1
 [0.2.2]: https://github.com/solentlabs/har-capture/compare/v0.2.1...v0.2.2
@@ -1181,4 +1184,4 @@ har-capture sanitize input.har --patterns custom-allowlist.json
 [0.8.2]: https://github.com/solentlabs/har-capture/compare/v0.8.1...v0.8.2
 [0.9.0]: https://github.com/solentlabs/har-capture/compare/v0.8.2...v0.9.0
 [0.9.1]: https://github.com/solentlabs/har-capture/compare/v0.9.0...v0.9.1
-[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.12.1...HEAD
+[unreleased]: https://github.com/solentlabs/har-capture/compare/v0.12.2...HEAD

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -272,6 +272,14 @@ customization.
 confidence. When a domain-specific pattern cannot guarantee zero false positives, it belongs in `heuristics.detectors`,
 not `pii.patterns`.
 
+A third home exists for rules that key on **markup structure** rather than value shape — the structural label/value
+patterns behind HTML pass 7c. These live as compiled patterns in `sanitization/html.py` rather than in `pii.json` for
+two reasons: the Pass 0 generic replacer substitutes the whole match, which would flatten the label markup these rules
+deliberately preserve; and `validate` and `check_for_pii` **import** them, which is what keeps the three detection paths
+from diverging. They meet the same 100%-confidence bar as `pii.patterns` — measured, not asserted, against every
+committed fleet capture. See
+[ADR-14](ARCHITECTURE_DECISIONS.md#adr-14-structural-position-not-value-shape-identifies-a-labeled-credential).
+
 **Two extension points, one policy.** The file-based `--patterns` flow above is the *static* extension point: merge
 happens once at load time and the merged set is cached. A *dynamic* extension point also exists for library callers that
 only know their pattern list at runtime — `sanitize_post_data(..., custom_patterns=...)` and

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -346,3 +346,75 @@ generic uppercase-alphanumeric backstop remains `medium` for exactly this reason
 **Consequence:** the review no longer sees vendor-format serials at all (they are redacted before flagging), and a
 contributor who skips the review still ships a serial-clean artifact for every layout the domain file knows. Unknown
 layouts remain where ADR-12 puts them: flagged for the human.
+
+## ADR-14: Structural Position, Not Value Shape, Identifies a Labeled Credential
+
+**Date:** 2026-08-23 · **Status:** Accepted · **Issue:** cable_modem_monitor#194
+
+**Context.** Technicolor gateways (XB6/XB7/XB8/XB10) render a "Device Label Information" block on `network_setup.jst`
+carrying four sticker values in plain text. The serial and WPS PIN were redacted; the default Wi-Fi password and SSID
+survived every heuristic mode, and `validate` returned 0 errors on a file containing all four. A contributor's real
+Wi-Fi password reached a public GitHub issue that way.
+
+The cause was neither label vocabulary nor value shape. Passes 2/2b/2d carry a tag chain `(?:<[^>]*>\s*)*` that hops
+`</span><span class="value">`; the password and SSID passes never received it, and their value character classes stop
+dead at `<`. Two committed fleet fixtures (XB7, XB10) still carry real default passwords for the same reason.
+
+**Decision.** Credential and network-name labels are matched by **structural position**, not by value shape and not by a
+bare tag chain.
+
+1. **The value must occupy its own element, as a single whitespace-free token.** Label element closes, value element
+   opens, the value is that element's entire text content and contains no whitespace. The element rule distinguishes a
+   sticker value from help-text prose: `$.i18n("<strong>Password:</strong> Enter the Password you registered")` shares a
+   text node with its label, while `<span class="value">` does not. The single-token rule is what the fleet measurement
+   could not supply — 40 captures prove the rule fires where it should, not that it stays silent on shapes those
+   captures happen not to contain. `<dt>Password:</dt><dd>Not set</dd>` and
+   `<div class="hint">Must be at least 8 characters</div>` are ordinary gateway markup, and the element rule alone
+   redacted both. Every real sticker value across the fleet is one token; every prose and status false positive is not.
+
+   This carries a cost, deliberately accepted: **an SSID containing a space is not matched by these rules.** A
+   space-bearing element text cannot be told apart from prose structurally, and under ADR-12 the burden of proof falls
+   on redacting rather than on preserving — destroying gateway UI copy is the worse failure.
+
+1. **Where no label exists, the naming element is the anchor.** An SSID rendered in `<font class="wifi_ntwrk">` or as
+   the options of `<select id="mac_ssid">` has no adjacent label at all. The element that names itself an SSID holder
+   supplies the anchor instead.
+
+1. **One pattern source, three consumers.** The patterns are defined once in `sanitization/html.py` and imported by
+   `validation/secrets.py` and `check_for_pii`. ADR-13 reconciled sanitize and validate for vendor serial *tokens*
+   specifically; that left the label/value layer structurally divergent, and `validate` had no label-anchored credential
+   check at all. Importing rather than restating is what prevents the next divergence.
+
+1. **A labeled password is an error; a network name is a warning.** The label states outright that the value is a
+   credential, so an unredacted match is deterministic in ADR-13's sense. An SSID identifies a network rather than
+   authenticating to it.
+
+**Rejected: routing HTML label/value text through the heuristic engine.** The engine already classifies both leaked
+values correctly, and doing so would close the class rather than a vocabulary list. But measured on the Technicolor
+captures it flags ~25% of *all* label/value pairs — `System Uptime`, `DHCP Lease Time`, `BOOT Version`, `Model`. In
+`REDACT` that destroys the diagnostic data the tool exists to preserve; in `FLAG` it floods the review UI. The path
+needs substantially wider `safe_value_patterns` before it can be trusted, which is separate work.
+
+**ADR-12 accounting** (a "redact more" change carries the burden of proof):
+
+- *Concrete leak closed:* a plaintext default Wi-Fi password on a public issue, plus the default and live SSIDs that
+  make it usable. Two committed fleet fixtures carry real values today.
+- *Fidelity cost:* four values per affected page, replaced by correlation-preserving `PASS_<hash>` / `WIFI_<hash>`
+  placeholders. Markup and whitespace are re-emitted verbatim, so sanitized fixtures keep their DOM structure and parser
+  tests still exercise the same selectors.
+- *Cannot-be-structure proof:* the rule fires only where a credential label or an SSID-naming attribute already declares
+  the value's meaning, and only on a single-token value that is not a known-safe status word. Measured precision across
+  the committed fleet is exact — the rules touch only the credentials and network names, and nothing else.
+
+**Symmetry requirement.** `validate` checks every response body, while `sanitize_html` runs only for HTML/XML mime
+types. The structural pass is therefore exposed as `redact_structural_credentials()` and applied to non-HTML text bodies
+too — otherwise a device-label block embedded in a `.js` body would be reported as an error that no sanitize run could
+clear. A check that can fail with no remediation path is worse than no check.
+
+**Consequence.** A capture of any Technicolor gateway in the family is sticker-clean without review, and `validate`
+fails (exit 1) rather than blessing a plaintext credential. Every guard exists against a reproduced false positive and
+is load-bearing — dropping one reintroduces it: no bare `key` (`metaKey` in minified jQuery); no `<th>` ("Source SSID
+Index"); no trailing-separator text (`<span id="priwifinet">Private Wi-Fi Network- </span>`); no whitespace in the value
+(hint and status text); no known-safe status word (`Enabled`, `Disabled`, `N/A`); no bare integers (row indices); no
+`<option value="">` (chooser placeholders like `-- Select --`); no attribute whose SSID token carries a helper suffix
+(`ssid_help`, `ssid-label`, `ssidTitle`); and no already-redacted value (re-sanitizing must not churn placeholders).

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -272,33 +272,34 @@ numbers.
 The engine runs sequential passes over HTML/JavaScript content (numbered 0–16 in the code, with sub-passes like 0b, 2b,
 7a/7b, 8b). Each pass uses regex substitution with callback functions that invoke the hasher.
 
-| Pass | Scanner                       | Pattern                                             | Redaction                              |
-| ---- | ----------------------------- | --------------------------------------------------- | -------------------------------------- |
-| 0    | Custom patterns               | Domain-specific PII regex                           | Per-pattern prefix                     |
-| 0b   | Web storage                   | `localStorage.setItem('KEY', 'VALUE')`              | Auto-redact if key is sensitive        |
-| 1    | MAC addresses                 | `([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}`             | `hasher.hash_mac()`                    |
-| 2    | Serial numbers (inline)       | `\bSN\b\|S/N\|Serial Number` + value                | `hasher.hash_value(val, "SERIAL")`     |
-| 2b   | Serial numbers (table)        | `<td>Label\b</td><td>VALUE</td>`                    | `hasher.hash_value(val, "SERIAL")`     |
-| 2c   | JS serial variables           | Names with serial+Number/Num/No or ending in serial | `hasher.hash_value(val, "SERIAL")`     |
-| 2d   | WPS / pairing / default PINs  | Known PIN label + 8-digit value (issue #47)         | `hasher.hash_value(val, "PIN")`        |
-| 2e   | Vendor-format serials         | High-confidence serial_number detectors, per token  | `hasher.hash_value(val, "SERIAL")`     |
-| 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value     | `hasher.hash_value(val, "ACCOUNT")`    |
-| 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)             | `hasher.hash_ip(ip, is_private=True)`  |
-| 5    | Public IPs                    | Non-private, non-reserved                           | `hasher.hash_ip(ip, is_private=False)` |
-| 6    | IPv6 addresses                | Full + compressed, validated via `ipaddress`        | `hasher.hash_ipv6()`                   |
-| 7    | Passwords/passphrases         | `password=value`, `passphrase=value`                | `hasher.hash_value(val, "PASS")`       |
-| 7a   | SSID text labels              | SSID labels in HTML text nodes                      | `hasher.hash_value(val, "WIFI")`       |
-| 7b   | JS password objects           | JavaScript object password fields                   | `hasher.hash_value(val, "PASS")`       |
-| 8    | Password inputs               | `<input type="password" value="...">`               | `hasher.hash_value(val, "PASS")`       |
-| 8b   | SSID inputs                   | SSID-related input fields                           | `hasher.hash_value(val, "WIFI")`       |
-| 9    | Session tokens                | 20+ char alphanumeric with label prefix             | `hasher.hash_value(val, "TOKEN")`      |
-| 10   | CSRF tokens                   | CSRF tokens in meta tags                            | `hasher.hash_value(val, "CSRF")`       |
-| 11   | Email addresses               | `user+tag@sub.domain.co.uk`                         | `hasher.hash_email()`                  |
-| 12   | Config paths                  | `.cfg` file references                              | `hasher.hash_value(val, "CONFIG")`     |
-| 13   | Vendor JS vars                | Motorola `var CurrentPw_24g = '...'`                | `hasher.hash_value(val, "PASS")`       |
-| 14   | Pipe-delimited (tagValueList) | `var name = "val1\|val2\|val3"`                     | Per-value heuristic analysis           |
-| 15   | Pipe-delimited (other)        | Other pipe-delimited variables                      | Per-value heuristic analysis           |
-| 16   | SSID fields in JS             | `ssid_24g: 'value'`, `guest_ssid: 'value'`          | `hasher.hash_value(val, "WIFI")`       |
+| Pass | Scanner                       | Pattern                                             | Redaction                               |
+| ---- | ----------------------------- | --------------------------------------------------- | --------------------------------------- |
+| 0    | Custom patterns               | Domain-specific PII regex                           | Per-pattern prefix                      |
+| 0b   | Web storage                   | `localStorage.setItem('KEY', 'VALUE')`              | Auto-redact if key is sensitive         |
+| 1    | MAC addresses                 | `([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}`             | `hasher.hash_mac()`                     |
+| 2    | Serial numbers (inline)       | `\bSN\b\|S/N\|Serial Number` + value                | `hasher.hash_value(val, "SERIAL")`      |
+| 2b   | Serial numbers (table)        | `<td>Label\b</td><td>VALUE</td>`                    | `hasher.hash_value(val, "SERIAL")`      |
+| 2c   | JS serial variables           | Names with serial+Number/Num/No or ending in serial | `hasher.hash_value(val, "SERIAL")`      |
+| 2d   | WPS / pairing / default PINs  | Known PIN label + 8-digit value (issue #47)         | `hasher.hash_value(val, "PIN")`         |
+| 2e   | Vendor-format serials         | High-confidence serial_number detectors, per token  | `hasher.hash_value(val, "SERIAL")`      |
+| 3    | Account/subscriber IDs        | `Account\|Subscriber\|Customer\|Device` + value     | `hasher.hash_value(val, "ACCOUNT")`     |
+| 4    | Private IPs                   | RFC 1918 ranges (preserves gateway IPs)             | `hasher.hash_ip(ip, is_private=True)`   |
+| 5    | Public IPs                    | Non-private, non-reserved                           | `hasher.hash_ip(ip, is_private=False)`  |
+| 6    | IPv6 addresses                | Full + compressed, validated via `ipaddress`        | `hasher.hash_ipv6()`                    |
+| 7    | Passwords/passphrases         | `password=value`, `passphrase=value`                | `hasher.hash_value(val, "PASS")`        |
+| 7a   | SSID text labels              | SSID labels in HTML text nodes                      | `hasher.hash_value(val, "WIFI")`        |
+| 7b   | JS password objects           | JavaScript object password fields                   | `hasher.hash_value(val, "PASS")`        |
+| 7c   | Structural label/value        | Value alone in its own element; SSID-named elements | `hasher.hash_value(val, "PASS"/"WIFI")` |
+| 8    | Password inputs               | `<input type="password" value="...">`               | `hasher.hash_value(val, "PASS")`        |
+| 8b   | SSID inputs                   | SSID-related input fields                           | `hasher.hash_value(val, "WIFI")`        |
+| 9    | Session tokens                | 20+ char alphanumeric with label prefix             | `hasher.hash_value(val, "TOKEN")`       |
+| 10   | CSRF tokens                   | CSRF tokens in meta tags                            | `hasher.hash_value(val, "CSRF")`        |
+| 11   | Email addresses               | `user+tag@sub.domain.co.uk`                         | `hasher.hash_email()`                   |
+| 12   | Config paths                  | `.cfg` file references                              | `hasher.hash_value(val, "CONFIG")`      |
+| 13   | Vendor JS vars                | Motorola `var CurrentPw_24g = '...'`                | `hasher.hash_value(val, "PASS")`        |
+| 14   | Pipe-delimited (tagValueList) | `var name = "val1\|val2\|val3"`                     | Per-value heuristic analysis            |
+| 15   | Pipe-delimited (other)        | Other pipe-delimited variables                      | Per-value heuristic analysis            |
+| 16   | SSID fields in JS             | `ssid_24g: 'value'`, `guest_ssid: 'value'`          | `hasher.hash_value(val, "WIFI")`        |
 
 **Pass 2c precision rule:** Matches variable names containing the compound `serial` + `number`/`num`/`no` (with optional
 separator), and names ending with `serial`. Does NOT match `serial` followed by unrelated suffixes (`Protocol`, `Port`,
@@ -318,13 +319,72 @@ deliberately **outside** `_sanitize_string_patterns`' perf length guard, so seri
 and
 [ADR-13](../ARCHITECTURE_DECISIONS.md#adr-13-high-confidence-vendor-serial-formats-are-deterministic--auto-redact-and-validate-error-delimiter-aware).
 
+### Sibling-Element and Structural Label/Value Rules
+
 **Sibling-element rule (passes 2, 2b, 2d):** The tag chain between a label and its value — `(?:<[^>]*>\s*)*` — permits
 whitespace between tags, so label/value pairs rendered in sibling elements match (e.g. Technicolor .jst on the XB6/XB7/
-XB8 family renders `<span class="readonlyLabel">Serial Number:</span>` with the value in a following sibling
+XB8/XB10 family renders `<span class="readonlyLabel">Serial Number:</span>` with the value in a following sibling
 `<span class="value">`). In passes 2 and 2d the separator-plus-tag run is captured and re-emitted verbatim, so redaction
 replaces only the value and preserves the intermediate markup — sanitized fixtures keep their DOM structure. The same
 whitespace-tolerant chain is used by the `serial_number` / `wps_pin` patterns in `pii.json` (`check_for_pii`) and the
 `SERIAL_PATTERNS` detectors in `validation/secrets.py`.
+
+**Structural label/value rule (pass 7c).** A bare tag chain is too loose for credential labels: its `\s*` also runs
+through ordinary prose, so gateway help text like
+`$.i18n("<strong>Password:</strong> Enter the Password you registered")` matches the word "Enter". Credential and SSID
+labels therefore use a *structural* rule instead of a lexical one — the value must occupy its **own element**:
+
+```text
+LABEL:  </tag>  <tag>  VALUE  </tag>
+        ^^^^^^  ^^^^^         ^^^^^
+        closes  opens         value is the element's entire text content
+```
+
+Help-text prose shares a text node with its `<strong>` label; a sticker value sits alone in `<span class="value">`.
+Requiring label-close then value-open then text then element-close is what separates them. Measured across the committed
+fleet captures this matches the four Device Label blocks and nothing else, where looser variants also matched minified
+jQuery and i18n prose.
+
+Pass 7c applies four patterns, all defined once in `sanitization/html.py` and **imported** by `validation/secrets.py`
+and `check_for_pii` so the three detection paths cannot diverge:
+
+| Pattern                   | Shape                                                               | Prefix |
+| ------------------------- | ------------------------------------------------------------------- | ------ |
+| `SIBLING_PASSWORD_RE`     | `password`/`passphrase`/`psk`/`wpa key` label, value in own element | `PASS` |
+| `SIBLING_SSID_RE`         | `ssid`/`network name`/`wi-fi network` label, `:` or `-` separator   | `WIFI` |
+| `SSID_ATTRIBUTE_RE`       | Element whose `class`/`id` names it an SSID holder                  | `WIFI` |
+| `iter_ssid_option_values` | `<option>` text inside an SSID-named `<select>`                     | `WIFI` |
+
+The value must also be a **single whitespace-free token**. The element rule alone still matched ordinary gateway markup
+that the fleet captures happen not to contain — `<dt>Password:</dt><dd>Not set</dd>` and
+`<div class="hint">Must be at least 8 characters</div>` were both redacted. Every real sticker value is one token; every
+prose and status false positive is not. The accepted cost is that an SSID containing a space is not matched.
+
+Guards, all applied by `is_structural_value_sensitive()` so the sanitizer, `validate`, and `check_for_pii` agree:
+
+- Bare `key` is dropped from the password vocabulary — a false-positive magnet across element boundaries (`metaKey`)
+- `<th>` is excluded from `SSID_ATTRIBUTE_RE`: a column heading is not a value ("Source SSID Index")
+- An attribute whose SSID token carries a helper suffix (`ssid_help`, `ssid-label`, `ssidTitle`, `ssid_desc`) names copy
+  *about* an SSID, not one — matching `ssid` as a bare substring redacted "Choose a name for your network"
+- Text ending in a separator is excluded — that is a label (`<span id="priwifinet">Private Wi-Fi Network- </span>`)
+- `<option value="">` is a chooser placeholder (`-- Select --`), never a network
+- Bare integers in an option list are row indices, mirroring the universal `^\d+$` entry in `SAFE_PATTERNS`
+- Known-safe status words (`Enabled`, `Disabled`, `N/A`) are rejected via `is_safe_value()`
+- Values passing `is_redacted()` are left untouched. These rules match on markup structure rather than value shape, so a
+  placeholder in the value element matches as readily as a credential; without the guard, re-sanitizing a fixture would
+  rewrite `[REDACTED]` to `PASS_<hash>` and churn captures that were already safe
+
+**Mime-type symmetry.** `validate` checks every response body, but `sanitize_html` runs only for HTML/XML. The pass is
+therefore exposed as `redact_structural_credentials()` and applied to non-HTML text bodies too, so validate can never
+report an error that no sanitize run could clear.
+
+**Why the heuristic engine does not cover this.** The engine classifies both leaked values correctly when handed them
+(`wifi_ssid` for a default SSID, `credential` for a three-word passphrase), but HTML label/value text is never routed to
+`analyze_value` — in `html.py` heuristics reach only `_sanitize_pipe_value` and the Web Storage scanner. That is why the
+leak was identical in all three heuristic modes. Routing span text through the engine was measured and rejected: it
+flags ~25% of all label/value pairs on the Technicolor captures (`System Uptime`, `DHCP Lease Time`, `BOOT Version`,
+`Model`), which would shred diagnostic data in `REDACT` and flood the review UI in `FLAG`. Widening
+`safe_value_patterns` far enough to make that path safe is separate work.
 
 ### Web Storage Scanner (Pass 0b)
 

--- a/docs/specs/SANITIZATION_SPEC.md
+++ b/docs/specs/SANITIZATION_SPEC.md
@@ -386,6 +386,25 @@ flags ~25% of all label/value pairs on the Technicolor captures (`System Uptime`
 `Model`), which would shred diagnostic data in `REDACT` and flood the review UI in `FLAG`. Widening
 `safe_value_patterns` far enough to make that path safe is separate work.
 
+### Idempotency Boundary
+
+Passes that emit a `PREFIX_<hash>` placeholder (serial, WPS PIN, account, password, SSID, token, CSRF, config, vendor JS
+vars, and the structural pass 7c) skip values `is_redacted()` already recognizes. Re-sanitizing an already-sanitized
+capture is therefore a byte-level no-op, even under the default random salt, and a placeholder can never be re-hashed.
+Pass 2 additionally admits `_` into its value class: without it the pass matched only the `SERIAL` prefix of its own
+output and prepended a fresh hash on every run, growing `SERIAL_<hash>_<hash>_<hash>...` without bound.
+
+The **format-preserving** passes (MAC, private IP, public IP, IPv6, email) deliberately do *not* take that guard and
+remain non-idempotent. Their placeholders are valid-looking values inside reserved ranges, so the guard cannot tell a
+placeholder from a real value: `02:aa:bb:cc:dd:ee` is a legitimate locally-administered MAC and `10.255.62.183` a
+legitimate private address, and both would pass through unredacted. Under ADR-12 the burden of proof falls on redacting
+less — cosmetic stability is not worth a leak. Two existing tests (`ipv6_compressed`,
+`test_full_flow_with_user_redactions`) pin this and fail if the guard is ever extended to these passes.
+
+Salt regeneration is a separate matter and is not a defect: `salt="auto"` mints a fresh salt per invocation and the salt
+is deliberately never persisted. Idempotency here comes from *skipping* already-redacted values, not from reproducing
+the same hash.
+
 ### Web Storage Scanner (Pass 0b)
 
 Detects `localStorage.setItem()` and `sessionStorage.setItem()` in inline scripts:

--- a/docs/specs/VALIDATION_SPEC.md
+++ b/docs/specs/VALIDATION_SPEC.md
@@ -180,7 +180,15 @@ flag-tier fields suppressed. The same model applies to every branch above (form 
 
 ### `check_content(content, location, findings, custom_patterns, *, has_sanitized_url_credential, serial_detectors)`
 
-Detects PII patterns in response content text:
+Detects PII patterns in response content text.
+
+**Whole-body redaction guard.** The early return uses `is_fully_redacted()`, not `is_redacted()`. `is_redacted()` is a
+single-*value* predicate that matches its allowlist families with `re.search`, so at body scale a run of six or more
+zeros (`0{6,}` — a separator-less zero MAC, a zeroed counter, a `#000000` in minified CSS) or a literal `XXX` /
+`REDACTED` anywhere in the body made the entire page look already-redacted and skipped every check below. That
+suppressed 209 of 750 committed fleet entries, including an XB10 page holding a plaintext default Wi-Fi password.
+`is_fully_redacted()` requires the whole string to be one opaque placeholder token: no whitespace, no markup, no
+structural punctuation, and a match accounting for the entire token rather than appearing inside it.
 
 **Bare base64 credentials:**
 
@@ -208,6 +216,19 @@ Severity: **error**
   labels) and a digit in the value (`serialize: function` matched `function` as a serial) — both reproduced as cosmetic
   noise on the CM2500 round-1 validate run
 - Checks via `is_redacted()` before reporting
+
+**Labeled credentials and network names (structural, error / warning):**
+
+- Imports the compiled patterns from `sanitization/html.py` (`SIBLING_PASSWORD_RE`, `SIBLING_SSID_RE`,
+  `SSID_ATTRIBUTE_RE`, `iter_ssid_option_values`) rather than restating them, so the sanitizer's pass 7c, `validate`,
+  and `check_for_pii` cannot drift apart on what counts as a labeled credential — the 0.12.1 reconciliation covered
+  vendor serial *tokens* only and left this layer divergent
+- A **password** in a labeled field is an **error**: the label states outright that the value is a credential, so an
+  unredacted match is a known leak, not a maybe (the ADR-13 determinism rule)
+- A **Wi-Fi network name** is a **warning**: an SSID identifies a network rather than authenticating to it
+- Values passing `is_redacted()` are skipped, so re-validating a sanitized capture stays quiet
+- See the structural label/value rule in
+  [`SANITIZATION_SPEC.md`](SANITIZATION_SPEC.md#sibling-element-and-structural-labelvalue-rules)
 
 **Vendor-format serials (delimiter-aware, error):**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "har-capture"
-version = "0.12.1"
+version = "0.12.2"
 description = "HAR capture and PII sanitization library for network traffic analysis"
 readme = "README.md"
 license = "MIT"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -109,9 +109,16 @@ else
 fi
 
 # ─── Step 4: integration (optional; requires chromium) ──────────────────────
+#
+# ``--cov-append`` mirrors CI's ``coverage`` job, which runs the unit suite with
+# ``--cov`` and then the integration suite with ``--cov-append`` so the gate
+# sees *combined* coverage. Without it, pytest's default ``addopts`` starts a
+# fresh coverage run over 26 tests and ``fail_under = 90`` rejects it at ~29% —
+# ``--integration`` could never pass, no matter the state of the tree.
 if [ "$INTEGRATION" = true ]; then
     echo -e "\n${YELLOW}[4/4] integration tests${NC}"
-    if "$PYTHON" -m pytest --tb=short -q -m "integration"; then
+    if "$PYTHON" -m pytest --tb=short -q -m "integration" \
+        --cov=har_capture --cov-append --cov-report=term-missing; then
         echo -e "${GREEN}✓ integration${NC}"
     else
         echo -e "${RED}✗ integration${NC}"

--- a/src/har_capture/__init__.py
+++ b/src/har_capture/__init__.py
@@ -24,7 +24,7 @@ Example usage:
 
 from __future__ import annotations
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 # Re-export public API for convenience
 from har_capture.sanitization import (

--- a/src/har_capture/patterns/__init__.py
+++ b/src/har_capture/patterns/__init__.py
@@ -26,6 +26,7 @@ from har_capture.patterns.redaction import (
     is_base64_credential,
     is_base64_decodable_text,
     is_cookie_attribute_metadata,
+    is_fully_redacted,
     is_redacted,
 )
 
@@ -46,6 +47,7 @@ __all__ = [
     "is_base64_credential",
     "is_base64_decodable_text",
     "is_cookie_attribute_metadata",
+    "is_fully_redacted",
     "is_redacted",
     # Hashing
     "Hasher",

--- a/src/har_capture/patterns/redaction.py
+++ b/src/har_capture/patterns/redaction.py
@@ -90,6 +90,83 @@ def is_redacted(value: str, custom_patterns: str | dict[str, Any] | None = None)
     return _check_patterns(value, allowlist)
 
 
+# A redaction placeholder is one opaque token: alphanumerics plus the punctuation
+# the placeholder formats actually use (`PASS_a1b2c3d4`, `XX:XX:XX:XX:XX:XX`,
+# `user_x@redacted.invalid`, `***SERIAL***`, `[REDACTED]`, `2001:db8::1`).
+# Structural punctuation — braces, quotes, semicolons, equals — means the string
+# is a document, not a placeholder.
+_PLACEHOLDER_TOKEN_RE = re.compile(r"[A-Za-z0-9_\-.:@\[\]*/]+")
+
+
+def is_fully_redacted(value: str, custom_patterns: str | dict[str, Any] | None = None) -> bool:
+    """Check if a string is *entirely* a redaction placeholder.
+
+    :func:`is_redacted` answers "does this value look redacted", and the
+    allowlist families backing it are matched with :func:`re.search` — correct
+    for a single field value, wrong for a whole document. A minified CSS body
+    carrying ``#000000``, a JSON body with ``"ver":"0.000000"``, or any body
+    containing the literal ``XXX`` would otherwise report as fully redacted and
+    skip every check the caller meant to run.
+
+    This predicate requires the whole string to be one placeholder token: no
+    whitespace, no markup, no structural punctuation, and a match that accounts
+    for the entire token rather than appearing somewhere inside it.
+
+    Args:
+        value: String to check
+        custom_patterns: Optional path to custom patterns file
+
+    Returns:
+        True if the whole string is a redaction placeholder
+
+    Examples:
+        >>> is_fully_redacted("[REDACTED]")
+        True
+        >>> is_fully_redacted("body{color:#000000}")
+        False
+        >>> is_fully_redacted("<p>hunter2</p>")
+        False
+    """
+    stripped = value.strip()
+    if not stripped or "<" in stripped or not _PLACEHOLDER_TOKEN_RE.fullmatch(stripped):
+        return False
+
+    allowlist = load_allowlist(custom_patterns)
+
+    if stripped in allowlist.get("static_placeholders", {}).get("values", []):
+        return True
+
+    # A hash prefix must account for the whole token, not just start it —
+    # `PASS_a1b2c3d4somethingelse` is not a placeholder.
+    for prefix in allowlist.get("hash_prefixes", {}).get("values", []):
+        if re.fullmatch(re.escape(prefix) + r"\w+", stripped):
+            return True
+
+    # Format-preserving patterns describe single-value formats and are
+    # deliberately one-sided (an IPv6 documentation *prefix*, an email
+    # *suffix*), so neither end can be anchored here. The token-class guard
+    # above is what stops a document from reaching this point.
+    format_patterns = allowlist.get("format_preserving_patterns", {})
+    for pattern_def in format_patterns.values():
+        if isinstance(pattern_def, dict) and "pattern" in pattern_def:
+            try:
+                if re.search(pattern_def["pattern"], stripped, re.IGNORECASE):
+                    return True
+            except re.error:
+                _LOGGER.warning("Skipping invalid format-preserving regex pattern")
+
+    # These are the unanchored ones (`XXX+`, `0{6,}`, `REDACTED`) — they must
+    # consume the entire token here, not merely appear within it.
+    for pattern in allowlist.get("redaction_patterns", {}).get("values", []):
+        try:
+            if re.fullmatch(pattern, stripped, re.IGNORECASE):
+                return True
+        except re.error:  # noqa: PERF203 - must check each pattern individually
+            _LOGGER.warning("Skipping invalid regex pattern in allowlist")
+
+    return False
+
+
 def is_allowlisted(value: str, allowlist: dict[str, Any] | None = None) -> bool:
     """Check if a value is in the allowlist.
 

--- a/src/har_capture/sanitization/har.py
+++ b/src/har_capture/sanitization/har.py
@@ -30,7 +30,12 @@ from har_capture.patterns import (
     load_sensitive_patterns,
 )
 from har_capture.sanitization.collector import RedactionCollector
-from har_capture.sanitization.html import is_valid_ip_address, redact_vendor_serials, sanitize_html
+from har_capture.sanitization.html import (
+    is_valid_ip_address,
+    redact_structural_credentials,
+    redact_vendor_serials,
+    sanitize_html,
+)
 from har_capture.sanitization.report import ConfidenceLevel
 
 if TYPE_CHECKING:
@@ -1343,7 +1348,17 @@ def _sanitize_response_content(
             custom_patterns=custom_patterns,
             heuristics=heuristics,
         )
-    elif "application/json" in mime_type:
+        return
+
+    # Structurally-located credentials (HTML engine pass 7c) for every other
+    # text-bearing body. `validate` checks *all* response bodies, so a device
+    # label block embedded in a `.js` or `application/javascript` body would
+    # otherwise be reported as an error that no sanitize run could clear —
+    # sanitize and validate must agree on what they can each see (ADR-14).
+    if hasher is not None and collector is not None and content.get("encoding") != "base64":
+        content["text"] = redact_structural_credentials(content["text"], hasher, collector, custom_patterns)
+
+    if "application/json" in mime_type:
         try:
             data = json.loads(content["text"])
             content["text"] = json.dumps(_sanitize_json_recursive(data, hasher, collector))

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 from har_capture.patterns import (
@@ -31,6 +32,7 @@ from har_capture.patterns import (
     load_pii_patterns,
     load_sensitive_patterns,
 )
+from har_capture.patterns.redaction import is_redacted
 
 if TYPE_CHECKING:
     from typing import Any
@@ -52,6 +54,181 @@ _ALREADY_REDACTED_HASH_RE = re.compile(r"^[A-Z_]+_[a-f0-9]{8}$")
 
 # MAC address pattern for pipe-delimited values (exact match)
 _PIPE_MAC_RE = re.compile(r"^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$")
+
+
+# Sibling-element label/value pairs where the value occupies its OWN element.
+# Technicolor .jst (XB6/XB7/XB8/XB10 family) renders the "Device Label
+# Information" sticker block on network_setup.jst as:
+#
+#     <span class="readonlyLabel">Default Password:</span>
+#     <span class="value">orange4213table</span>
+#
+# Passes 2/2b/2d reach their values with a bare tag chain `(?:<[^>]*>\s*)*`,
+# but a bare chain is too loose for credential labels: its `\s*` also runs
+# through ordinary prose, so gateway help text such as
+#
+#     $.i18n("<strong>Password:</strong> Enter the Password you registered")
+#
+# matches the word "Enter". The discriminator is structural, not lexical —
+# help-text prose shares a text node with its label element, while a sticker
+# value opens its own element and is that element's entire text content.
+#
+# The value may not contain whitespace. Every sticker value across the
+# committed fleet is a single token, while every hint, status, and prose
+# false positive is not:
+#
+#     <label>Password:</label><div class="hint">Must be at least 8 characters</div>
+#     <dt>Password:</dt><dd>Not set</dd>
+#
+# Requiring the element's entire text to be one whitespace-free token rejects
+# those without needing to know what the words mean. The cost is a genuine
+# limitation: an SSID containing a space is not matched by these rules. That is
+# the deliberate side of the ADR-12 trade — a space-containing element text
+# cannot be told apart from prose structurally, and over-redacting gateway UI
+# copy is the worse failure.
+#
+# The optional `\([^)]{0,24}\)` group carries the parenthetical qualifier
+# Technicolor puts between label and colon ("Default Network Name (SSID):").
+#
+# Exported (not underscore-private) because `validation/secrets.py` imports
+# these: the sanitizer and the validator must not diverge on what counts as a
+# labeled default credential. See ADR-14.
+def _sibling_label_value_pattern(labels: str, separators: str = ":") -> re.Pattern[str]:
+    """Build a pattern matching `<tag>LABEL:</tag><tag>VALUE</tag>` pairs.
+
+    Args:
+        labels: Regex alternation of label texts (already escaped/grouped).
+        separators: Accepted label/value separator characters. Each is escaped
+            individually — interpolating them raw would let a future addition
+            silently form a range (``":-="`` becoming ``[:-=]``, which matches
+            ``;`` and ``<``).
+
+    Returns:
+        Compiled pattern with group 1 = label through the value element's
+        opening tag (re-emitted verbatim so markup is preserved) and group 2 =
+        the value itself.
+    """
+    separator_class = "[" + "".join(re.escape(c) for c in separators) + "]"
+    return re.compile(
+        r"((?:" + labels + r")\s*(?:\([^)]{0,24}\))?\s*" + separator_class + r"\s*"
+        r"</[a-zA-Z][^>]*>\s*"  # label element closes
+        r"<[a-zA-Z][^>]*>\s*)"  # value element opens
+        r"([^<>\s]+)"  # value: the element's entire text, one token
+        r"(?=\s*</)",  # value element closes
+        re.IGNORECASE,
+    )
+
+
+# Label vocabulary mirrors pass 7 minus bare `key`, which is a false-positive
+# magnet once the match may cross element boundaries (`metaKey`, `monkey`).
+SIBLING_PASSWORD_RE = _sibling_label_value_pattern(r"password|passphrase|psk|wpa[0-9]*\s*key")
+
+# SSID vocabulary extends pass 7a with the connection-status heading form,
+# which separates label from value with a hyphen rather than a colon:
+#     <span id="priwifinet">Private Wi-Fi Network- </span>
+#     <span class="connection_text">Andrew</span>
+# That heading renders the *live* SSID, not the sticker default — the xb6
+# capture carries a household member's given name there.
+SIBLING_SSID_RE = _sibling_label_value_pattern(r"ssid|network\s*name|wi-?fi\s*network", separators=":-")
+
+# Attribute-anchored SSID values: the element naming itself an SSID holder via
+# class/id carries the network name as its text, with no adjacent label at all.
+#     <td headers="private-Name"><b><font class="wifi_ntwrk">XFSETUP-9210</font></b></td>
+#
+# The attribute must name a *value* holder. Classes like `ssid_help`,
+# `ssid-label`, `ssidTitle`, and `ssid_desc` decorate copy about the SSID rather
+# than holding one, and matching `ssid` as a bare substring redacted their text
+# ("Choose a name for your network"). Helper suffixes are therefore excluded,
+# and `<th>` stays excluded because a column heading is not a value
+# ("Source SSID Index").
+_SSID_ATTRIBUTE_HELPER_SUFFIX = r"(?:help|label|desc|descr|description|title|tip|hint|note|msg|message|text|error|caption|legend|head|header)"
+SSID_ATTRIBUTE_RE = re.compile(
+    r"(<(?!th[\s>])[a-zA-Z][\w-]*[^>]*\b(?:class|id)\s*=\s*[\"'][^\"']*"
+    r"(?:ssid|wifi_ntwrk|wifi[-_]?network|priwifinet|wireless[-_]?name)"
+    r"(?![-_]?" + _SSID_ATTRIBUTE_HELPER_SUFFIX + r")"
+    r"[^\"']*[\"'][^>]*>\s*)"
+    r"([^<>\s]+)"  # value: the element's entire text, one token
+    r"(?=\s*</)",
+    re.IGNORECASE,
+)
+
+# SSID values listed as the options of an SSID-named <select>. The network name
+# has no label and no attribute of its own here — only the enclosing control
+# identifies it:
+#     <select name="mac_ssid" id="mac_ssid"><option value="17">XFSETUP-9210</option></select>
+SSID_SELECT_RE = re.compile(
+    r"<select\b[^>]*\b(?:name|id|class)\s*=\s*[\"'][^\"']*ssid[^\"']*[\"'][^>]*>.*?</select>",
+    re.IGNORECASE | re.DOTALL,
+)
+# Group 1 is the opening tag, group 2 the option text. An option whose `value`
+# attribute is empty is a chooser placeholder ("-- Select --"), never a network.
+SSID_OPTION_RE = re.compile(
+    r"(<option\b(?![^>]*\bvalue\s*=\s*[\"']\s*[\"'])[^>]*>\s*)([^<>\s]+)(?=\s*</option>)",
+    re.IGNORECASE,
+)
+
+
+def is_structural_value_sensitive(value: str, custom_patterns: str | dict[str, Any] | None = None) -> bool:
+    r"""Check whether a structurally-located element value should be redacted.
+
+    The patterns above locate a value by markup position; this decides whether
+    the located text is actually a credential or network name. Shared by the
+    sanitizer, ``validate``, and ``check_for_pii`` so a value one of them
+    redacts is never reported as a leak by another.
+
+    Rejects, in order: labels (text ending in a separator, as in
+    ``<span id="priwifinet">Private Wi-Fi Network-</span>``), values already
+    redacted, bare integers (row indices — mirroring the universal ``^\\d+$``
+    entry in ``SAFE_PATTERNS``), and known-safe status words (``Enabled``,
+    ``Disabled``, ``N/A``) that appear in the same element position as a value.
+
+    Args:
+        value: The element's text content
+        custom_patterns: Optional path to custom patterns file
+
+    Returns:
+        True if the value should be treated as sensitive
+    """
+    from har_capture.sanitization.heuristics import is_safe_value
+
+    if not value or value.endswith((":", "-")):
+        return False
+    if _OPTION_INDEX_RE.match(value):
+        return False
+    if is_redacted(value, custom_patterns):
+        return False
+    return not is_safe_value(value)
+
+
+# Bare integers are row indices, not network names. This mirrors the universal
+# `^\d+$` entry in heuristics.SAFE_PATTERNS.
+_OPTION_INDEX_RE = re.compile(r"^\d+$")
+
+
+def iter_ssid_option_values(
+    content: str, custom_patterns: str | dict[str, Any] | None = None
+) -> Iterator[tuple[str, int]]:
+    """Yield ``(value, offset)`` for sensitive options inside SSID-named selects.
+
+    Shared by the sanitizer, ``validate``, and ``check_for_pii`` so all three
+    agree on which option values are network names.
+
+    Args:
+        content: HTML content to scan.
+        custom_patterns: Optional path to custom patterns file.
+
+    Yields:
+        The option's text and its offset **within ``content``**. The offset is
+        rebased onto the document — ``SSID_OPTION_RE`` runs against the matched
+        ``<select>`` substring, so its own offsets are relative to that element
+        and would report the wrong line number.
+    """
+    for select_match in SSID_SELECT_RE.finditer(content):
+        base = select_match.start()
+        for option_match in SSID_OPTION_RE.finditer(select_match.group(0)):
+            value = option_match.group(2)
+            if is_structural_value_sensitive(value, custom_patterns):
+                yield value, base + option_match.start(2)
 
 
 def _sanitize_pipe_value(
@@ -686,6 +863,22 @@ def _sanitize_html_impl(
         flags=re.IGNORECASE,
     )
 
+    # 7c. Sibling-element sticker labels (Device Label Information block).
+    # The value lives in its own element rather than inline after the label, so
+    # the inline passes above cannot reach it: their value class stops at `<`.
+    # Runs after passes 7/7a/7b so an already-redacted inline match is not
+    # re-processed; it is otherwise independent of them. The label run and the
+    # value element's opening tag are re-emitted verbatim (mirroring passes 2
+    # and 2d), so redaction replaces only the value and sanitized fixtures keep
+    # their DOM structure.
+    #
+    # A default Wi-Fi password printed on the device sticker is a live
+    # credential, not device metadata: XB7/XB10 captures reached a public issue
+    # with it in plain text (issue #194). The default SSID is redacted
+    # alongside it — the pair together identifies the household's network, and
+    # the SSID is what makes the password usable.
+    html = redact_structural_credentials(html, hasher, collector, custom_patterns)
+
     # 8. Password input fields
     def replace_password_input(match: re.Match[str]) -> str:
         collector.record_auto_redaction("password")
@@ -847,6 +1040,55 @@ def _sanitize_html_impl(
     return html
 
 
+def redact_structural_credentials(
+    content: str,
+    hasher: Hasher,
+    collector: RedactionCollector,
+    custom_patterns: str | dict[str, Any] | None = None,
+) -> str:
+    """Redact structurally-located credentials and network names (pass 7c).
+
+    All four patterns share a shape: group 1 is the markup run up to the value
+    (re-emitted verbatim so the DOM survives), group 2 is the value. Whether the
+    located text is actually sensitive is decided by
+    :func:`is_structural_value_sensitive`, the same predicate ``validate`` and
+    :func:`check_for_pii` use.
+
+    Exposed separately from :func:`sanitize_html` because ``validate`` checks
+    **every** response body while ``sanitize_html`` runs only for HTML/XML
+    mime types. A body carrying this markup under any other mime type would
+    otherwise be flagged as an error that no sanitize run could clear.
+
+    Args:
+        content: Text to scan (HTML, or any body that may embed it)
+        hasher: Hasher for placeholder generation
+        collector: Redaction collector for counts
+        custom_patterns: Optional path to custom patterns file
+
+    Returns:
+        Content with structurally-located credentials replaced
+    """
+
+    def make_replacer(prefix: str, category: str) -> Any:
+        def replace(match: re.Match[str]) -> str:
+            value = match.group(2)
+            if not is_structural_value_sensitive(value, custom_patterns):
+                return match.group(0)
+            collector.record_auto_redaction(category)
+            return f"{match.group(1)}{hasher.hash_generic(value, prefix)}"
+
+        return replace
+
+    content = SIBLING_PASSWORD_RE.sub(make_replacer("PASS", "password"), content)
+    content = SIBLING_SSID_RE.sub(make_replacer("WIFI", "wifi"), content)
+    content = SSID_ATTRIBUTE_RE.sub(make_replacer("WIFI", "wifi"), content)
+
+    def replace_select(match: re.Match[str]) -> str:
+        return SSID_OPTION_RE.sub(make_replacer("WIFI", "wifi"), match.group(0))
+
+    return SSID_SELECT_RE.sub(replace_select, content)
+
+
 def check_for_pii(
     content: str,
     filename: str = "",
@@ -873,6 +1115,42 @@ def check_for_pii(
     pii = load_pii_patterns(custom_patterns)
     allowlist = load_allowlist(custom_patterns)
     findings: list[dict[str, Any]] = []
+
+    # Labeled default credentials in sibling-element label/value pairs. These
+    # live as compiled patterns rather than pii.json entries because the pass-0
+    # generic replacer substitutes the whole match, which would flatten the
+    # label markup this pattern deliberately preserves. Sharing the compiled
+    # patterns keeps all three detection paths — sanitizer pass 7c, `validate`,
+    # and this CI fixture gate — from drifting apart (issue #194).
+    for sibling_pattern, sibling_name in (
+        (SIBLING_PASSWORD_RE, "default_password_label"),
+        (SIBLING_SSID_RE, "default_ssid_label"),
+        (SSID_ATTRIBUTE_RE, "ssid_attribute"),
+    ):
+        for match in sibling_pattern.finditer(content):
+            value = match.group(2)
+            if not is_structural_value_sensitive(value, custom_patterns) or is_allowlisted(value, allowlist):
+                continue
+            findings.append(
+                {
+                    "pattern": sibling_name,
+                    "match": value,
+                    "line": content.count("\n", 0, match.start(2)) + 1,
+                    "filename": filename,
+                }
+            )
+
+    for option_value, option_offset in iter_ssid_option_values(content, custom_patterns):
+        if is_allowlisted(option_value, allowlist):
+            continue
+        findings.append(
+            {
+                "pattern": "ssid_select_option",
+                "match": option_value,
+                "line": content.count("\n", 0, option_offset) + 1,
+                "filename": filename,
+            }
+        )
 
     for pattern_name, pattern_def in pii.get("patterns", {}).items():
         if not isinstance(pattern_def, dict) or "regex" not in pattern_def:

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -1167,7 +1167,10 @@ def check_for_pii(
     ):
         for match in sibling_pattern.finditer(content):
             value = match.group(2)
-            if not is_structural_value_sensitive(value, custom_patterns) or is_allowlisted(value, allowlist):
+            # No separate allowlist check: is_structural_value_sensitive()
+            # already runs is_redacted(), and both resolve to the same
+            # _check_patterns() over the same loaded allowlist.
+            if not is_structural_value_sensitive(value, custom_patterns):
                 continue
             findings.append(
                 {
@@ -1179,8 +1182,6 @@ def check_for_pii(
             )
 
     for option_value, option_offset in iter_ssid_option_values(content, custom_patterns):
-        if is_allowlisted(option_value, allowlist):
-            continue
         findings.append(
             {
                 "pattern": "ssid_select_option",

--- a/src/har_capture/sanitization/html.py
+++ b/src/har_capture/sanitization/html.py
@@ -639,6 +639,16 @@ def _sanitize_html_impl(
         flags=re.IGNORECASE,
     )
 
+    # Idempotency boundary: passes that emit a `PREFIX_<hash>` placeholder skip
+    # values `is_redacted()` already recognizes, so re-sanitizing is a no-op and
+    # a placeholder can never be re-hashed into a compounding
+    # `SERIAL_<hash>_<hash>` chain. The format-preserving passes below (MAC, IPs,
+    # IPv6, email) deliberately do NOT take that guard: their placeholders are
+    # valid-looking values in reserved ranges, indistinguishable from real ones.
+    # `02:aa:bb:cc:dd:ee` is a legitimate locally-administered MAC and
+    # `10.255.62.183` a legitimate private address — skipping them to buy
+    # cosmetic stability would leak real values. They stay non-idempotent by
+    # design; ADR-12 puts the burden of proof on redacting less, not more.
     # 1. MAC Addresses (various formats: XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX)
     def replace_mac(match: re.Match[str]) -> str:
         collector.record_auto_redaction("mac_address")
@@ -653,6 +663,8 @@ def _sanitize_html_impl(
     # The separator + tag run is captured and re-emitted verbatim so redaction
     # replaces only the value and preserves the surrounding markup.
     def replace_serial(match: re.Match[str]) -> str:
+        if is_redacted(match.group(3), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("serial_number")
         label = match.group(1)
         sep = match.group(2)
@@ -660,7 +672,7 @@ def _sanitize_html_impl(
         return f"{label}{sep}{hasher.hash_generic(serial, 'SERIAL')}"
 
     html = re.sub(
-        r"\b(Serial\s*Number|SerialNum|SN|S/N)\b(\s*[:\s=]*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-]{5,})",
+        r"\b(Serial\s*Number|SerialNum|SN|S/N)\b(\s*[:\s=]*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-_]{5,})",
         replace_serial,
         html,
         flags=re.IGNORECASE,
@@ -669,6 +681,8 @@ def _sanitize_html_impl(
     # 2b. Serial numbers in HTML table cells (label in one <td>, value in next <td>)
     # Handles: <td>...<strong>Serial Number</strong>...</td>\s*<td>VALUE</td>
     def replace_serial_table(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("serial_number")
         prefix = match.group(1)
         serial = match.group(2)
@@ -676,7 +690,7 @@ def _sanitize_html_impl(
         return f"{prefix}{hashed}"
 
     html = re.sub(
-        r"(<td[^>]*>\s*(?:<[^>]*>\s*)*(?:Serial\s*Number|SerialNum|SN|S/N)\b\s*(?:<[^>]*>\s*)*</td>\s*<td[^>]*>\s*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-]{5,})(?=\s*(?:<[^>]*>\s*)*</td>)",
+        r"(<td[^>]*>\s*(?:<[^>]*>\s*)*(?:Serial\s*Number|SerialNum|SN|S/N)\b\s*(?:<[^>]*>\s*)*</td>\s*<td[^>]*>\s*(?:<[^>]*>\s*)*)([a-zA-Z0-9\-_]{5,})(?=\s*(?:<[^>]*>\s*)*</td>)",
         replace_serial_table,
         html,
         flags=re.IGNORECASE,
@@ -690,6 +704,8 @@ def _sanitize_html_impl(
     # Tag chain and separator handling mirror pass 2: whitespace-tolerant
     # sibling-element matching, with the separator + tag run preserved.
     def replace_wps_pin(match: re.Match[str]) -> str:
+        if is_redacted(match.group(3), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("wps_pin")
         label = match.group(1)
         sep = match.group(2)
@@ -708,6 +724,8 @@ def _sanitize_html_impl(
     # Matches: names ending with "serial" (e.g., deviceSerial, modem_serial)
     # Does NOT match: serial+Port, serial+Protocol, serial+Baud, serialization, serialized
     def replace_js_serial(match: re.Match[str]) -> str:
+        if is_redacted(match.group(4), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("serial_number")
         label = match.group(1)
         sep = match.group(2)
@@ -822,6 +840,8 @@ def _sanitize_html_impl(
 
     # 7. Passwords/Passphrases in HTML forms or text
     def replace_password(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("password")
         label = match.group(1)
         return f"{label}={hasher.hash_generic(match.group(2), 'PASS')}"
@@ -835,6 +855,8 @@ def _sanitize_html_impl(
 
     # 7a. SSID labels in HTML text (<p>SSID: MyNetwork</p>)
     def replace_ssid_text(match: re.Match[str]) -> str:
+        if is_redacted(match.group(3), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("wifi")
         label = match.group(1)
         sep = match.group(2)
@@ -849,6 +871,8 @@ def _sanitize_html_impl(
 
     # 7b. JavaScript object password fields (password_24g: 'value', guest_password: 'value')  # pragma: allowlist secret
     def replace_js_password(match: re.Match[str]) -> str:
+        if is_redacted(match.group(4), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("password")
         label = match.group(1)
         sep = match.group(2)
@@ -881,6 +905,8 @@ def _sanitize_html_impl(
 
     # 8. Password input fields
     def replace_password_input(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("password")
         prefix = match.group(1)
         suffix = match.group(3)
@@ -896,6 +922,8 @@ def _sanitize_html_impl(
     # 8b. SSID input fields (input following SSID label)
     # Matches: <label>...SSID...</label><input value="...">
     def replace_ssid_input(match: re.Match[str]) -> str:
+        if is_redacted(match.group(3), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("wifi")
         prefix = match.group(1)
         value_start = match.group(2)
@@ -911,6 +939,8 @@ def _sanitize_html_impl(
 
     # 9. Session tokens/cookies (long alphanumeric strings)
     def replace_token(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("token")
         label = match.group(1)
         return f"{label}={hasher.hash_generic(match.group(2), 'TOKEN')}"
@@ -924,6 +954,8 @@ def _sanitize_html_impl(
 
     # 10. CSRF tokens in meta tags
     def replace_csrf(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("csrf")
         prefix = match.group(1)
         suffix = match.group(3)
@@ -950,6 +982,8 @@ def _sanitize_html_impl(
 
     # 12. Config file paths (may contain ISP/customer identifiers)
     def replace_config(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("config")
         label = match.group(1)
         return f"{label}: {hasher.hash_generic(match.group(2), 'CONFIG')}"
@@ -963,6 +997,8 @@ def _sanitize_html_impl(
 
     # 13. Motorola JavaScript password variables
     def replace_motorola_pw(match: re.Match[str]) -> str:
+        if is_redacted(match.group(2), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("password")
         prefix = match.group(1)
         suffix = match.group(3)
@@ -1023,6 +1059,8 @@ def _sanitize_html_impl(
 
     # 16. SSID fields in JavaScript objects (ssid_24g: 'value', guest_ssid: 'value')
     def replace_js_ssid(match: re.Match[str]) -> str:
+        if is_redacted(match.group(4), custom_patterns):
+            return match.group(0)
         collector.record_auto_redaction("wifi")
         label = match.group(1)
         sep = match.group(2)

--- a/src/har_capture/validation/secrets.py
+++ b/src/har_capture/validation/secrets.py
@@ -34,11 +34,19 @@ from har_capture.patterns.redaction import (
     is_base64_credential,
     is_base64_decodable_text,
     is_cookie_attribute_metadata,
+    is_fully_redacted,
 )
 from har_capture.patterns.redaction import (
     is_redacted as check_if_redacted,
 )
-from har_capture.sanitization.html import is_valid_ip_address
+from har_capture.sanitization.html import (
+    SIBLING_PASSWORD_RE,
+    SIBLING_SSID_RE,
+    SSID_ATTRIBUTE_RE,
+    is_structural_value_sensitive,
+    is_valid_ip_address,
+    iter_ssid_option_values,
+)
 from har_capture.validation.completeness import load_har
 
 # Cookie attribute-only values (not actual session data)
@@ -703,7 +711,15 @@ def check_content(
             candidate tokens. ``None`` compiles them from ``custom_patterns``;
             ``validate_har`` pre-compiles once per file.
     """
-    if not content or is_redacted(content, custom_patterns):
+    # `content` is a whole response body, so the whole-string form is required.
+    # `is_redacted` matches its allowlist families with `re.search` — right for
+    # a single field value, wrong for a document. A run of six or more zeros
+    # (`0{6,}` — a separator-less zero MAC, a zeroed counter, a `#000000` in
+    # minified CSS) or a literal `XXX` / `REDACTED` anywhere in the body was
+    # enough to skip every content check for that entry. 209 of 750 committed
+    # fleet entries were being skipped this way, including an XB10 page
+    # carrying a plaintext default Wi-Fi password (issue #194).
+    if not content or is_fully_redacted(content, custom_patterns):
         return
 
     stripped = content.strip()
@@ -761,6 +777,49 @@ def check_content(
                         reason="Potential serial number",
                     )
                 )
+
+    # Labeled default credentials in sibling-element label/value pairs
+    # (Technicolor "Device Label Information" sticker block). The SAME compiled
+    # patterns the sanitizer's pass 7c uses are imported here, so the two
+    # cannot drift apart on what counts as a labeled default credential — the
+    # 0.12.1 serial reconciliation fixed that for vendor serial tokens only,
+    # leaving this layer divergent (validate had no label-anchored credential
+    # check at all).
+    #
+    # Severity for the password is error, matching ADR-13's rule for
+    # deterministic matches: the label states outright that the value is a
+    # password, so an unredacted match is a known credential leak, not a maybe.
+    # This is the gate that blessed a contributor's real Wi-Fi password on its
+    # way to a public issue (issue #194). The SSID is a warning — it identifies
+    # the network rather than authenticating to it.
+    for sibling_pattern, sibling_severity, sibling_reason in (
+        (SIBLING_PASSWORD_RE, "error", "Plaintext password in a labeled field"),
+        (SIBLING_SSID_RE, "warning", "Wi-Fi network name (SSID) in a labeled field"),
+        (SSID_ATTRIBUTE_RE, "warning", "Wi-Fi network name (SSID) in an SSID-named element"),
+    ):
+        for match in sibling_pattern.finditer(content):
+            value = match.group(2)
+            if is_structural_value_sensitive(value, custom_patterns):
+                findings.append(
+                    Finding(
+                        severity=sibling_severity,
+                        location=location,
+                        field="content",
+                        value=truncate(value),
+                        reason=sibling_reason,
+                    )
+                )
+
+    for option_value, _offset in iter_ssid_option_values(content, custom_patterns):
+        findings.append(
+            Finding(
+                severity="warning",
+                location=location,
+                field="content",
+                value=truncate(option_value),
+                reason="Wi-Fi network name (SSID) in an SSID-named dropdown",
+            )
+        )
 
     # Vendor-format serials as standalone tokens — delimiter-aware. Mirrors
     # the sanitizer's redact_vendor_serials pass: the same high-confidence

--- a/tests/fixtures/test_html.json
+++ b/tests/fixtures/test_html.json
@@ -160,6 +160,34 @@
     {"value": "QAM256",             "expected_unchanged": true,  "id": "modulation_safe"}
   ],
 
+  "device_label_block_cases": [
+    {"html": "<font class=\"wifi_ntwrk\">A</font>", "redacted_values": ["A"], "preserved_markup": "class=\"wifi_ntwrk\"", "id": "ssid_attribute_single_character"},
+    {"html": "<div class=\"module forms dev_label\"><h2>Device Label Information</h2>\n<div class=\"form-row \"><span class=\"readonlyLabel\">Default Network Name (SSID):</span><span class=\"value\">WIFI-AAAA</span></div>\n<div class=\"form-row odd\"><span class=\"readonlyLabel\">Default Password:</span><span class=\"value\">orange4213table</span></div>\n<div class=\"form-row \"><span class=\"readonlyLabel\">WPS PIN:</span><span class=\"value\">18345592</span></div>\n<div class=\"form-row odd \"><span class=\"readonlyLabel\" id=\"sernum\">Serial Number:</span><span class=\"value\">4106844207105213</span></div></div>", "redacted_values": ["WIFI-AAAA", "orange4213table", "18345592", "4106844207105213"], "preserved_markup": "<span class=\"readonlyLabel\">Default Password:</span>", "id": "technicolor_device_label_block_all_four"},
+    {"html": "<div class=\"form-row odd\">\n\t<span class=\"readonlyLabel\">Default Password:</span>\n\t<span class=\"value\">\n\torange4213table</span>\n</div>", "redacted_values": ["orange4213table"], "preserved_markup": "<span class=\"value\">", "id": "sibling_span_default_password_whitespace"},
+    {"html": "<span class=\"readonlyLabel\">Default Network Name (SSID):</span><span class=\"value\">WIFI-AAAA</span>", "redacted_values": ["WIFI-AAAA"], "preserved_markup": "<span class=\"value\">", "id": "sibling_span_default_ssid_parenthetical_label"},
+    {"html": "<h2><div class=\"ssid-style\"><span id=\"priwifinet\">Private Wi-Fi Network- </span>\n<span class=\"connection_text\">WIFI-AAAA</span></div></h2>", "redacted_values": ["WIFI-AAAA"], "preserved_markup": "<span class=\"connection_text\">", "id": "sibling_span_ssid_hyphen_separator"},
+    {"html": "<td headers=\"private-Name\"><b><font color=\"black\" class=\"wifi_ntwrk\">WIFI-AAAA</font></b></td>", "redacted_values": ["WIFI-AAAA"], "preserved_markup": "class=\"wifi_ntwrk\"", "id": "ssid_attribute_anchored_table_cell"},
+    {"html": "<select name=\"mac_ssid\" id=\"mac_ssid\"><option value=\"1\">1</option><option value=\"17\">WIFI-AAAA</option></select>", "redacted_values": ["WIFI-AAAA"], "preserved_markup": "<option value=\"17\">", "id": "ssid_select_option"}
+  ],
+
+  "device_label_preserve_cases": [
+    {"html": "<label for=\"pw\">Password:</label>\n<div class=\"hint\">Must be at least 8 characters</div>", "preserved": "Must be at least 8 characters", "id": "password_hint_text_multiword"},
+    {"html": "<dt>Password:</dt>\n<dd>Not set</dd>", "preserved": "Not set", "id": "password_status_not_set"},
+    {"html": "<td>SSID:</td><td>Enabled</td>", "preserved": "Enabled", "id": "ssid_status_enabled"},
+    {"html": "<div class=\"ssid_help\">Choose a name for your network</div>", "preserved": "Choose a name for your network", "id": "ssid_help_class_prose"},
+    {"html": "<div class=\"ssid-label\">Network</div>", "preserved": "Network", "id": "ssid_label_class_single_word"},
+    {"html": "<div class=\"ssidTitle\">Wireless</div>", "preserved": "Wireless", "id": "ssid_title_class"},
+    {"html": "<select id=\"ssid_select\"><option value=\"\">-- Select --</option></select>", "preserved": "-- Select --", "id": "ssid_select_empty_value_placeholder"},
+    {"html": "<select id=\"ssid_select\"><option value=\"0\">Disabled</option></select>", "preserved": "Disabled", "id": "ssid_select_status_option"},
+    {"html": "<select id=\"wl_ssid_idx\" class=\"ssidsel\"><option>2.4 GHz</option><option>5 GHz</option></select>", "preserved": "2.4 GHz", "id": "ssid_select_band_option"},
+    {"html": "$(\"#dyndnstip4\").html($.i18n(\"<strong>Password:</strong> Password registered with the service provider\"))", "preserved": "Password registered with the service provider", "id": "i18n_help_text_password_prose"},
+    {"html": "$(\"#wireedttip1\").html($.i18n(\"<strong>Network Name (SSID):</strong> Identifies your home network from other nearby networks\"))", "preserved": "Identifies your home network", "id": "i18n_help_text_ssid_prose"},
+    {"html": "<th id=\"SourceSSIDIndex\" width=\"20%\">Source SSID Index</th><th id=\"DestSSIDIndex\" width=\"30%\">Destination SSID Index</th>", "preserved": "Source SSID Index", "id": "ssid_table_column_headings"},
+    {"html": "<span id=\"priwifinet\">Private Wi-Fi Network- </span>", "preserved": "Private Wi-Fi Network-", "id": "ssid_label_element_itself"},
+    {"html": "<select id=\"mac_ssid\"><option value=\"1\">17</option></select>", "preserved": "17", "id": "ssid_select_bare_index_option"},
+    {"html": "<span class=\"readonlyLabel\">Default Password:</span><span class=\"value\">[REDACTED]</span>", "preserved": "[REDACTED]", "id": "already_redacted_placeholder_untouched"}
+  ],
+
   "expected_patterns": [
     "mac_address",
     "email",

--- a/tests/test_patterns/test_redaction.py
+++ b/tests/test_patterns/test_redaction.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 import pytest
 
-from har_capture.patterns.redaction import is_allowlisted, is_redacted
+from har_capture.patterns.redaction import is_allowlisted, is_fully_redacted, is_redacted
 
 # Load test data from fixture
 _FIXTURES = json.loads((Path(__file__).parent.parent / "fixtures" / "test_redaction.json").read_text())
@@ -391,3 +391,32 @@ class TestErrorHandling:
             assert is_redacted("[REDACTED]", custom_patterns=custom_path)
         finally:
             Path(custom_path).unlink(missing_ok=True)
+
+
+class TestIsFullyRedactedInvalidPatterns:
+    """A malformed allowlist regex must be skipped, not crash the scan.
+
+    ``is_fully_redacted`` compiles every allowlist family at call time; a bad
+    pattern in a user-supplied ``--patterns`` file would otherwise abort the
+    whole-body guard and take ``check_content`` down with it.
+    """
+
+    # Passed flat: load_allowlist() merges a dict straight onto the builtin
+    # allowlist. Nesting it under an "allowlist" key silently contributes
+    # nothing and the test would pass without reaching either handler.
+    BAD_ALLOWLIST = {
+        "format_preserving_patterns": {"bad": {"pattern": "[unterminated"}},
+        "redaction_patterns": {"values": ["(also-unterminated"]},
+    }
+
+    def test_invalid_patterns_are_skipped_not_raised(self) -> None:
+        """Test malformed regexes in both families are skipped gracefully."""
+        assert is_fully_redacted("SomeValue", self.BAD_ALLOWLIST) is False
+
+    def test_valid_patterns_still_match_alongside_invalid_ones(self) -> None:
+        """Test a good pattern still matches when a bad one precedes it."""
+        allowlist = {
+            "format_preserving_patterns": {"bad": {"pattern": "[unterminated"}},
+            "redaction_patterns": {"values": ["(bad"]},
+        }
+        assert is_fully_redacted("[REDACTED]", allowlist) is True

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -457,6 +457,85 @@ class TestDeviceLabelCheckForPii:
         assert matched[0]["line"] == 4
 
 
+class TestIdempotencyBoundary:
+    """Re-sanitizing must not re-hash a placeholder — except where it must.
+
+    Passes emitting a ``PREFIX_<hash>`` placeholder skip values already
+    recognized as redacted, so a sweep over already-sanitized fixtures is a
+    no-op and a serial can never compound into ``SERIAL_<hash>_<hash>``.
+
+    The format-preserving passes deliberately do **not** take that guard. Their
+    placeholders are valid-looking values in reserved ranges and cannot be told
+    apart from real ones: ``02:aa:bb:cc:dd:ee`` is a legitimate
+    locally-administered MAC, ``10.255.62.183`` a legitimate private address.
+    Skipping them to buy cosmetic stability would leak real values.
+    """
+
+    PREFIX_HASH_CASES = [
+        ("<span>Serial Number:</span><span>4106844207105213</span>", "serial_sibling"),
+        ("<td><strong>Serial Number</strong></td><td>4106844207105213</td>", "serial_table"),
+        ("var o={serialNumber:'4106844207105213'};", "js_serial"),
+        ("<span>WPS PIN:</span><span>18345592</span>", "wps_pin"),
+        ("<p>Account ID: 998877665</p>", "account_id"),
+        ("<p>password=hunter2xyz</p>", "password_inline"),
+        ("<p>SSID: MyNet-5G</p>", "ssid_inline"),
+        ("var o={password_24g:'hunter2xyz'};", "js_password"),
+        ("<span>Default Password:</span><span>orange4213table</span>", "structural_password"),
+        ('<input type="password" value="hunter2xyz">', "password_input"),
+        ('<label>SSID</label><input value="MyNet">', "ssid_input"),
+        ("var o={ssid_24g:'MyNet'};", "js_ssid"),
+    ]
+
+    @pytest.mark.parametrize(("html", "desc"), PREFIX_HASH_CASES, ids=[c[1] for c in PREFIX_HASH_CASES])
+    def test_prefix_hash_passes_are_idempotent(self, html: str, desc: str) -> None:
+        """Test re-sanitizing is a byte-level no-op under independent random salts.
+
+        The default ``salt="auto"`` mints a fresh salt per call, so this also
+        proves the guard skips the value rather than re-hashing it to the same
+        string by luck.
+        """
+        once = sanitize_html(html)
+        twice = sanitize_html(once)
+        thrice = sanitize_html(twice)
+        assert once == twice == thrice, f"{desc}: re-sanitizing should be a no-op"
+
+    def test_serial_placeholder_does_not_compound(self) -> None:
+        """Test a serial placeholder is never re-hashed into a chain.
+
+        Pass 2's value class excluded ``_``, so it matched only the ``SERIAL``
+        prefix of its own output and prepended a fresh hash on every run —
+        ``SERIAL_9f8e3528_9f8e3528_60ec920f``, growing without bound.
+        """
+        html = "<span>Serial Number:</span><span>4106844207105213</span>"
+        for _ in range(4):
+            html = sanitize_html(html, salt="fixed-salt")
+        assert html.count("SERIAL_") == 1, f"placeholder compounded: {html}"
+
+    FORMAT_PRESERVING_CASES = [
+        ("<p>02:aa:bb:cc:dd:ee</p>", "02:aa:bb:cc:dd:ee", "locally_administered_mac"),
+        ("<p>10.255.62.183</p>", "10.255.62.183", "private_ip_in_placeholder_range"),
+        ("<p>2001:db8::1</p>", "2001:db8::1", "ipv6_documentation_range"),
+        ("<p>192.0.2.5</p>", "192.0.2.5", "public_ip_test_net"),
+    ]
+
+    @pytest.mark.parametrize(
+        ("html", "value", "desc"),
+        FORMAT_PRESERVING_CASES,
+        ids=[c[2] for c in FORMAT_PRESERVING_CASES],
+    )
+    def test_format_preserving_passes_still_redact_real_values(
+        self, html: str, value: str, desc: str
+    ) -> None:
+        """Test values inside placeholder ranges are still redacted, not skipped.
+
+        These are real addresses a real capture can contain. Guarding them on
+        ``is_redacted()`` for idempotency's sake would pass them through
+        unredacted — a leak traded for cosmetic stability.
+        """
+        result = sanitize_html(html, salt="fixed-salt")
+        assert value not in result, f"{desc}: must still be redacted"
+
+
 # =============================================================================
 # Web Storage setItem() Scanning (Gap 1 fix)
 # =============================================================================

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -32,6 +32,7 @@ import pytest
 from har_capture.patterns import load_allowlist, load_pii_patterns
 from har_capture.sanitization.html import (
     check_for_pii,
+    is_structural_value_sensitive,
     sanitize_html,
 )
 from har_capture.sanitization.report import HeuristicMode
@@ -499,6 +500,64 @@ class TestIdempotencyBoundary:
         thrice = sanitize_html(twice)
         assert once == twice == thrice, f"{desc}: re-sanitizing should be a no-op"
 
+    # Each case carries both a redacted and a live form of the SAME markup. The
+    # live form proves the pass's pattern really reaches that value; without it
+    # a test asserting "output == input" passes trivially whenever the pattern
+    # simply never matched.
+    GUARD_SKIP_CASES = [
+        (
+            "<span>Serial Number:</span><span>SERIAL_a1b2c3d4</span>",
+            "<span>Serial Number:</span><span>4106844207105213</span>",
+            "serial_label",
+        ),
+        (
+            "<span>WPS PIN:</span><span>00000000</span>",
+            "<span>WPS PIN:</span><span>18345592</span>",
+            "wps_pin",
+        ),
+        (
+            "<p>token=XXXXXXXXXXXXXXXXXXXXXX</p>",
+            "<p>token=a9f3k2m7q1w8e4r6t5y0u3</p>",
+            "session_token",
+        ),
+        (
+            '<meta name="csrf-token" content="CSRF_a1b2c3d4">',
+            '<meta name="csrf-token" content="k2m7q1w8e4r6">',
+            "csrf_token",
+        ),
+        (
+            "<p>Config File Name: CONFIG_a1b2c3d4.cfg</p>",
+            "<p>Config File Name: cust00219abc.cfg</p>",
+            "config_path",
+        ),
+        (
+            "<script>var CurrentPw = 'PASS_a1b2c3d4';</script>",
+            "<script>var CurrentPw = 'hunter2xyz';</script>",
+            "motorola_password",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        ("redacted_html", "live_html", "desc"),
+        GUARD_SKIP_CASES,
+        ids=[c[2] for c in GUARD_SKIP_CASES],
+    )
+    def test_already_redacted_values_are_left_untouched(
+        self, redacted_html: str, live_html: str, desc: str
+    ) -> None:
+        """Test each prefix-hash pass skips a value that is already a placeholder.
+
+        Exercises the guard's *skip* branch specifically — the path that keeps a
+        sweep from re-hashing, and the one a passing suite can silently leave
+        uncovered.
+        """
+        assert sanitize_html(live_html, salt="test") != live_html, (
+            f"{desc}: precondition — the pass must actually match this markup"
+        )
+        assert sanitize_html(redacted_html, salt="test") == redacted_html, (
+            f"{desc}: an already-redacted value must be left untouched"
+        )
+
     def test_serial_placeholder_does_not_compound(self) -> None:
         """Test a serial placeholder is never re-hashed into a chain.
 
@@ -510,6 +569,33 @@ class TestIdempotencyBoundary:
         for _ in range(4):
             html = sanitize_html(html, salt="fixed-salt")
         assert html.count("SERIAL_") == 1, f"placeholder compounded: {html}"
+
+    STRUCTURAL_VALUE_CASES = [
+        ("Private Wi-Fi Network-", False, "label_trailing_hyphen"),
+        ("Serial Number:", False, "label_trailing_colon"),
+        ("", False, "empty_value"),
+        ("17", False, "bare_index"),
+        ("Enabled", False, "safe_status_word"),
+        ("PASS_a1b2c3d4", False, "already_redacted"),
+        ("orange4213table", True, "real_credential"),
+        ("XFSETUP-9210", True, "real_ssid"),
+        ("A", True, "single_character_ssid"),
+    ]
+
+    @pytest.mark.parametrize(
+        ("value", "expected", "desc"),
+        STRUCTURAL_VALUE_CASES,
+        ids=[c[2] for c in STRUCTURAL_VALUE_CASES],
+    )
+    def test_structural_value_predicate(self, value: str, expected: bool, desc: str) -> None:
+        """Test the shared predicate directly, including branches no markup reaches.
+
+        A label whose text ends in a separator is rejected here, but the
+        patterns' no-whitespace value rule means real label markup like
+        ``Private Wi-Fi Network- `` never reaches the predicate — so the branch
+        needs a direct test to be exercised at all.
+        """
+        assert is_structural_value_sensitive(value) is expected, desc
 
     FORMAT_PRESERVING_CASES = [
         ("<p>02:aa:bb:cc:dd:ee</p>", "02:aa:bb:cc:dd:ee", "locally_administered_mac"),

--- a/tests/test_sanitization/test_html.py
+++ b/tests/test_sanitization/test_html.py
@@ -34,6 +34,7 @@ from har_capture.sanitization.html import (
     check_for_pii,
     sanitize_html,
 )
+from har_capture.sanitization.report import HeuristicMode
 
 # =============================================================================
 # Load Test Data From Fixture
@@ -70,6 +71,15 @@ SERIAL_TABLE_CASES = [(c["html"], c["serial_value"], c["id"]) for c in _FIXTURE[
 SERIAL_SIBLING_SPAN_CASES = [
     (c["html"], c["redacted_value"], c["preserved_markup"], c["id"])
     for c in _FIXTURE["serial_sibling_span_cases"]
+]
+
+DEVICE_LABEL_BLOCK_CASES = [
+    (c["html"], c["redacted_values"], c["preserved_markup"], c["id"])
+    for c in _FIXTURE["device_label_block_cases"]
+]
+
+DEVICE_LABEL_PRESERVE_CASES = [
+    (c["html"], c["preserved"], c["id"]) for c in _FIXTURE["device_label_preserve_cases"]
 ]
 
 SETITEM_CASES = [
@@ -272,6 +282,182 @@ class TestSerialNumberSiblingSpans:
 
 
 # =============================================================================
+# Device Label Information Block (issue #194)
+# =============================================================================
+
+
+class TestDeviceLabelBlock:
+    """Sticker values rendered with the value in its own element.
+
+    Technicolor .jst (XB6/XB7/XB8/XB10) renders a "Device Label Information"
+    block whose four sticker values sit in a sibling ``<span class="value">``.
+    The serial and WPS PIN were reachable via the pass 2/2d tag chain, but the
+    default Wi-Fi password and SSID were not, and survived every heuristic mode
+    — a contributor's real Wi-Fi password reached a public issue that way.
+
+    All markup below is synthetic; the values are fabricated.
+    """
+
+    @pytest.mark.parametrize(
+        ("html", "redacted_values", "preserved_markup", "desc"),
+        DEVICE_LABEL_BLOCK_CASES,
+        ids=[c[3] for c in DEVICE_LABEL_BLOCK_CASES],
+    )
+    def test_sticker_values_redacted_markup_preserved(
+        self, html: str, redacted_values: list[str], preserved_markup: str, desc: str
+    ) -> None:
+        """Test sticker values are redacted without collapsing the surrounding markup."""
+        result = sanitize_html(html, salt="test")
+        for value in redacted_values:
+            assert value not in result, f"{desc}: {value!r} should be redacted"
+        assert preserved_markup in result, f"{desc}: intermediate markup should be preserved"
+
+    @pytest.mark.parametrize(
+        ("html", "redacted_values", "preserved_markup", "desc"),
+        DEVICE_LABEL_BLOCK_CASES,
+        ids=[c[3] for c in DEVICE_LABEL_BLOCK_CASES],
+    )
+    def test_redaction_holds_in_every_heuristic_mode(
+        self, html: str, redacted_values: list[str], preserved_markup: str, desc: str
+    ) -> None:
+        """Test redaction does not depend on the heuristic mode.
+
+        The original defect was invisible to the heuristic setting: HTML label/
+        value text is never routed through the heuristic engine, so all three
+        modes leaked identically.
+        """
+        for mode in HeuristicMode:
+            result = sanitize_html(html, salt="test", heuristics=mode)
+            for value in redacted_values:
+                assert value not in result, f"{desc}: {value!r} should be redacted in {mode}"
+
+    @pytest.mark.parametrize(
+        ("html", "preserved", "desc"),
+        DEVICE_LABEL_PRESERVE_CASES,
+        ids=[c[2] for c in DEVICE_LABEL_PRESERVE_CASES],
+    )
+    def test_prose_and_headings_preserved(self, html: str, preserved: str, desc: str) -> None:
+        """Test the structural rules do not fire on help text, headings, or placeholders."""
+        result = sanitize_html(html, salt="test")
+        assert preserved in result, f"{desc}: {preserved!r} should be preserved"
+
+    @pytest.mark.parametrize(
+        ("html", "redacted_values", "preserved_markup", "desc"),
+        DEVICE_LABEL_BLOCK_CASES,
+        ids=[c[3] for c in DEVICE_LABEL_BLOCK_CASES],
+    )
+    def test_sanitization_is_idempotent(
+        self, html: str, redacted_values: list[str], preserved_markup: str, desc: str
+    ) -> None:
+        """Test re-sanitizing already-sanitized markup is a no-op.
+
+        These rules match on markup structure rather than value shape, so a
+        placeholder in the value element matches as readily as a credential.
+        Without the already-redacted guard a fixture sweep would rewrite every
+        placeholder on each run.
+        """
+        once = sanitize_html(html, salt="test")
+        twice = sanitize_html(once, salt="test")
+        assert once == twice, f"{desc}: re-sanitizing should be a no-op"
+
+
+class TestDeviceLabelCheckForPii:
+    """The CI fixture gate must see the Device Label block too.
+
+    ``check_for_pii`` is the third detection path (alongside the sanitizer and
+    ``validate``); before this it returned zero findings on a block holding a
+    plaintext default Wi-Fi password.
+    """
+
+    @pytest.mark.parametrize(
+        ("html", "expected_pattern", "expected_match", "desc"),
+        [
+            (
+                '<span class="readonlyLabel">Default Password:</span>'
+                '<span class="value">orange4213table</span>',
+                "default_password_label",
+                "orange4213table",
+                "sibling_span_password",
+            ),
+            (
+                '<span class="readonlyLabel">Default Network Name (SSID):</span>'
+                '<span class="value">WIFI-AAAA</span>',
+                "default_ssid_label",
+                "WIFI-AAAA",
+                "sibling_span_ssid",
+            ),
+            (
+                '<td><font class="wifi_ntwrk">WIFI-AAAA</font></td>',
+                "ssid_attribute",
+                "WIFI-AAAA",
+                "ssid_attributed_element",
+            ),
+            (
+                '<select id="mac_ssid"><option value="17">WIFI-AAAA</option></select>',
+                "ssid_select_option",
+                "WIFI-AAAA",
+                "ssid_select_option",
+            ),
+        ],
+    )
+    def test_device_label_values_detected(
+        self, html: str, expected_pattern: str, expected_match: str, desc: str
+    ) -> None:
+        """Test check_for_pii reports each structurally-identified value."""
+        findings = check_for_pii(html, "fixture.html")
+        matched = [f for f in findings if f["pattern"] == expected_pattern]
+        assert len(matched) == 1, f"{desc}: expected one {expected_pattern} finding"
+        assert matched[0]["match"] == expected_match
+        assert matched[0]["filename"] == "fixture.html"
+
+    def test_bare_index_option_not_reported(self) -> None:
+        """Test numeric option values are treated as row indices, not network names."""
+        html = '<select id="mac_ssid"><option value="1">17</option></select>'
+        findings = check_for_pii(html, "fixture.html")
+        assert [f for f in findings if f["pattern"] == "ssid_select_option"] == []
+
+    def test_redacted_values_not_reported(self) -> None:
+        """Test allowlisted placeholders are not re-reported as leaks."""
+        html = '<span class="readonlyLabel">Default Password:</span><span class="value">***REDACTED***</span>'
+        findings = check_for_pii(html, "fixture.html")
+        assert [f for f in findings if f["pattern"] == "default_password_label"] == []
+
+    def test_redacted_select_option_not_reported(self) -> None:
+        """Test an already-redacted option value is not re-reported as a leak."""
+        html = '<select id="mac_ssid"><option value="17">***REDACTED***</option></select>'
+        findings = check_for_pii(html, "fixture.html")
+        assert [f for f in findings if f["pattern"] == "ssid_select_option"] == []
+
+    def test_select_option_line_number_is_document_relative(self) -> None:
+        """Test option line numbers are rebased onto the document.
+
+        ``SSID_OPTION_RE`` runs against the matched ``<select>`` substring, so
+        its own offsets are relative to that element; without rebasing, a value
+        on line 103 was reported as line 6.
+        """
+        content = (
+            "\n" * 100 + '<div>\n<select id="mac_ssid">\n<option value="17">WIFI-AAAA</option>\n</select>'
+        )
+        findings = check_for_pii(content, "fixture.html")
+        matched = [f for f in findings if f["pattern"] == "ssid_select_option"]
+        assert len(matched) == 1
+        expected = content[: content.index("WIFI-AAAA")].count("\n") + 1
+        assert matched[0]["line"] == expected
+
+    def test_reported_line_number_points_at_the_value(self) -> None:
+        """Test the reported line is the value's line, not the block's first line."""
+        html = (
+            "<div>\n<div>\n"
+            '<span class="readonlyLabel">Default Password:</span>\n'
+            '<span class="value">orange4213table</span>\n</div>\n</div>'
+        )
+        findings = check_for_pii(html, "fixture.html")
+        matched = [f for f in findings if f["pattern"] == "default_password_label"]
+        assert len(matched) == 1
+        assert matched[0]["line"] == 4
+
+
+# =============================================================================
 # Web Storage setItem() Scanning (Gap 1 fix)
 # =============================================================================
 
@@ -316,8 +502,6 @@ class TestSetItemScanning:
 
     def test_setitem_heuristic_redact_mode(self) -> None:
         """Test Tier C: heuristic REDACT mode auto-redacts high-entropy values."""
-        from har_capture.sanitization.report import HeuristicMode
-
         # High-entropy value with mixed character types that should trigger credential heuristic
         html = 'localStorage.setItem("config_data", "xK9mP2qR7sT4wZ")'
         result = sanitize_html(html, salt="test", heuristics=HeuristicMode.REDACT)
@@ -330,7 +514,6 @@ class TestSetItemScanning:
         """Test Tier C: heuristic FLAG mode preserves value but records flag."""
         from har_capture.patterns import Hasher
         from har_capture.sanitization.collector import RedactionCollector
-        from har_capture.sanitization.report import HeuristicMode
 
         hasher = Hasher.create("test")
         collector = RedactionCollector(hasher=hasher)

--- a/tests/test_validation/test_secrets.py
+++ b/tests/test_validation/test_secrets.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from har_capture.patterns.loader import resolve_patterns_arg
+from har_capture.patterns.redaction import is_fully_redacted
 from har_capture.validation.secrets import (
     Finding,
     check_content,
@@ -698,6 +699,205 @@ class TestCheckContentSerialInTable:
         check_content(html, "Entry 0 (content)", findings)
         serial_findings = [f for f in findings if "serial" in f.reason.lower()]
         assert len(serial_findings) >= 1, "Should flag serial number in sibling spans"
+
+
+class TestDeviceLabelCredentials:
+    """Labeled default credentials in the Technicolor Device Label block.
+
+    ``validate`` is documented as the step that "confirms nothing leaked", so
+    a plaintext default Wi-Fi password must be an error, not a warning and not
+    silence. Before this check the gate returned 0 errors on a capture holding
+    all four sticker values (issue #194).
+
+    All markup below is synthetic; the values are fabricated.
+    """
+
+    DEVICE_LABEL_BLOCK = (
+        '<div class="form-row "><span class="readonlyLabel">Default Network Name (SSID):</span>'
+        '<span class="value">WIFI-AAAA</span></div>\n'
+        '<div class="form-row odd"><span class="readonlyLabel">Default Password:</span>'
+        '<span class="value">orange4213table</span></div>'
+    )
+
+    def test_default_password_is_an_error(self) -> None:
+        """Test an unredacted labeled default password fails the gate."""
+        findings: list[Finding] = []
+        check_content(self.DEVICE_LABEL_BLOCK, "Entry 0 (content)", findings)
+        password_findings = [f for f in findings if "password" in f.reason.lower()]
+        assert len(password_findings) == 1, "Should flag the labeled default password"
+        assert password_findings[0].severity == "error", "A plaintext credential is an error"
+        assert password_findings[0].value == "orange4213table"
+
+    def test_default_ssid_is_a_warning(self) -> None:
+        """Test an unredacted labeled default SSID is reported as a warning."""
+        findings: list[Finding] = []
+        check_content(self.DEVICE_LABEL_BLOCK, "Entry 0 (content)", findings)
+        ssid_findings = [f for f in findings if "ssid" in f.reason.lower()]
+        assert len(ssid_findings) == 1, "Should flag the labeled default SSID"
+        assert ssid_findings[0].severity == "warning", "An SSID identifies but does not authenticate"
+
+    @pytest.mark.parametrize(
+        ("html", "expected_reason", "desc"),
+        [
+            (
+                '<h2><span id="priwifinet">Private Wi-Fi Network- </span>'
+                '<span class="connection_text">WIFI-AAAA</span></h2>',
+                "labeled field",
+                "hyphen_separated_heading",
+            ),
+            (
+                '<td headers="private-Name"><font class="wifi_ntwrk">WIFI-AAAA</font></td>',
+                "ssid-named element",
+                "attribute_anchored_cell",
+            ),
+            (
+                '<select id="mac_ssid"><option value="17">WIFI-AAAA</option></select>',
+                "ssid-named dropdown",
+                "select_option",
+            ),
+        ],
+    )
+    def test_unlabeled_ssid_surfaces_flagged(self, html: str, expected_reason: str, desc: str) -> None:
+        """Test SSIDs rendered without an adjacent label are still flagged."""
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        matched = [f for f in findings if expected_reason in f.reason.lower()]
+        assert len(matched) >= 1, f"{desc}: should flag the network name"
+        assert matched[0].value == "WIFI-AAAA"
+
+    def test_redacted_value_skipped_without_masking_a_later_leak(self) -> None:
+        """Test a redacted value is skipped while a later unredacted one still flags.
+
+        Guards the skip path itself: an early ``is_redacted`` hit must advance
+        the scan rather than abandon it.
+        """
+        html = (
+            '<td><font class="wifi_ntwrk">***REDACTED***</font></td>'
+            '<td><font class="wifi_ntwrk">WIFI-AAAA</font></td>'
+            '<select id="mac_ssid">'
+            '<option value="1">***REDACTED***</option>'
+            '<option value="2">WIFI-BBBB</option>'
+            "</select>"
+        )
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        flagged = {f.value for f in findings if "ssid" in f.reason.lower()}
+        assert flagged == {"WIFI-AAAA", "WIFI-BBBB"}, f"unexpected findings: {flagged}"
+
+    @pytest.mark.parametrize(
+        ("html", "desc"),
+        [
+            (
+                '<td><font class="wifi_ntwrk">***REDACTED***</font></td>',
+                "already_redacted_ssid_attributed_element",
+            ),
+            (
+                '<select id="mac_ssid"><option value="17">***REDACTED***</option></select>',
+                "already_redacted_select_option",
+            ),
+        ],
+    )
+    def test_redacted_values_alone_produce_no_findings(self, html: str, desc: str) -> None:
+        """Test content holding only redacted values yields nothing."""
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        assert [f for f in findings if "ssid" in f.reason.lower()] == [], desc
+
+    @pytest.mark.parametrize(
+        ("html", "desc"),
+        [
+            (
+                '$.i18n("<strong>Password:</strong> Password registered with the service provider")',
+                "i18n_help_text_password",
+            ),
+            (
+                '$.i18n("<strong>Network Name (SSID):</strong> Identifies your home network")',
+                "i18n_help_text_ssid",
+            ),
+            ('<th id="SourceSSIDIndex">Source SSID Index</th>', "table_column_heading"),
+            (
+                '<span class="readonlyLabel">Default Password:</span><span class="value">[REDACTED]</span>',
+                "already_redacted_placeholder",
+            ),
+        ],
+    )
+    def test_prose_headings_and_placeholders_not_flagged(self, html: str, desc: str) -> None:
+        """Test the checks stay silent on help text, headings, and redacted values."""
+        findings: list[Finding] = []
+        check_content(html, "Entry 0 (content)", findings)
+        noisy = [f for f in findings if "password" in f.reason.lower() or "ssid" in f.reason.lower()]
+        assert noisy == [], f"{desc}: should not be flagged, got {[f.reason for f in noisy]}"
+
+
+class TestContentCheckNotSkippedByStrayPlaceholder:
+    """A placeholder somewhere in a body must not skip the whole content check.
+
+    ``check_content`` guarded its early return with ``is_redacted``, a
+    single-value predicate that matches its allowlist families with
+    ``re.search``. A run of six or more zeros (``0{6,}``) or a literal ``XXX`` /
+    ``REDACTED`` anywhere in a body made the whole page look already-redacted —
+    209 of 750 committed fleet entries were skipped that way, including an XB10
+    page holding a plaintext default Wi-Fi password (issue #194).
+    """
+
+    LEAK_MARKUP = (
+        '<span class="readonlyLabel">Default Password:</span><span class="value">orange4213table</span>'
+    )
+
+    @pytest.mark.parametrize(
+        ("prefix", "desc"),
+        [
+            ("<p>CM MAC: 000000000000</p>", "zero_run_separatorless_mac"),
+            ("<p>Uptime counter: 0000000</p>", "zero_run_counter"),
+            ("<style>body{color:#000000}</style>", "zero_run_in_css_color"),
+            ("<p>Serial: XXX</p>", "xxx_placeholder"),
+            ("<p>Status: REDACTED</p>", "redacted_literal"),
+        ],
+    )
+    def test_stray_placeholder_does_not_suppress_a_real_leak(self, prefix: str, desc: str) -> None:
+        """Test a body mixing a placeholder token and a real credential still flags.
+
+        Each prefix is verified to actually trip the old ``is_redacted`` guard,
+        so the test would fail against the previous implementation rather than
+        passing for unrelated reasons.
+        """
+        body = prefix + self.LEAK_MARKUP
+        assert is_redacted(body), f"{desc}: precondition — this must trip the OLD guard"
+
+        findings: list[Finding] = []
+        check_content(body, "Entry 0 (content)", findings)
+        errors = [f for f in findings if f.severity == "error"]
+        assert errors, f"{desc}: the placeholder must not suppress the credential check"
+        assert any(f.value == "orange4213table" for f in errors), desc
+
+    def test_body_that_is_only_a_placeholder_is_still_skipped(self) -> None:
+        """Test the original intent is preserved: a wholly-redacted body is skipped."""
+        findings: list[Finding] = []
+        check_content("[REDACTED]", "Entry 0 (content)", findings)
+        assert findings == []
+
+    @pytest.mark.parametrize(
+        ("content", "expected", "desc"),
+        [
+            ("[REDACTED]", True, "static_placeholder"),
+            ("  PASS_a1b2c3d4  ", True, "hash_prefix_with_surrounding_space"),
+            ("***SERIAL***", True, "star_wrapped_placeholder"),
+            ("000000000000", True, "bare_zero_run"),
+            ("XX:XX:XX:XX:XX:XX", True, "format_preserving_mac"),
+            ("user_x@redacted.invalid", True, "format_preserving_email"),
+            ("<p>hunter2</p>", False, "markup"),
+            ("body{color:#000000}", False, "minified_css_with_zero_run"),
+            ('{"cls":"xxx","password":"hunter2"}', False, "minified_json_with_xxx"),
+            ('PASS_a1b2c3d4{"password":"x"}', False, "placeholder_prefixing_a_document"),
+            ("000000 and a real value", False, "placeholder_plus_prose"),
+            ("", False, "empty"),
+        ],
+    )
+    def test_is_fully_redacted_requires_the_whole_string(
+        self, content: str, expected: bool, desc: str
+    ) -> None:
+        """Test the whole-string predicate rejects mere containment."""
+        assert is_fully_redacted(content) is expected, desc
 
 
 class TestValidateHarBase64Content:


### PR DESCRIPTION
**Release target: 0.12.2** (patch — `Security` + `Fixed`)

## The bug

Technicolor gateways (XB6/XB7/XB8/XB10) render a "Device Label Information" block on `network_setup.jst` carrying four sticker values in plain text. The serial and WPS PIN were redacted; the **default Wi-Fi password and SSID survived in every heuristic mode**, and `har-capture validate` returned 0 errors on a file containing all four — so the step documented as "confirms nothing leaked" blessed a plaintext Wi-Fi credential.

A contributor's real Wi-Fi password reached a public GitHub issue this way (solentlabs/cable_modem_monitor#194).

## Root cause

Neither label vocabulary nor value shape. Passes 2/2b/2d carry a tag chain that hops `</span><span class="value">`; the password and SSID passes never received it, and their value classes stop dead at `<`. HTML label/value text is also never routed to the heuristic engine — which is why the leak was identical in `DISABLED`, `FLAG`, and `REDACT`.

## The fix

New **pass 7c** matches by *structural position*: the value must occupy its own element and be a single whitespace-free token. That separates a sticker value from gateway help text (which shares a text node with its label) and from hint/status markup like `<dt>Password:</dt><dd>Not set</dd>`. Also covered are SSIDs rendered with no adjacent label — in an SSID-named element, or as the options of an SSID-named `<select>`.

The sanitizer, `validate`, and `check_for_pii` now import **one** set of compiled patterns and one shared `is_structural_value_sensitive()` predicate, so the three cannot drift again. Because `validate` checks every response body while `sanitize_html` runs only for HTML/XML, the pass is exposed as `redact_structural_credentials()` and applied to non-HTML text bodies too — a check that can fail with no remediation path is worse than no check.

See ADR-14.

## A second, larger hole

`check_content` guarded its early return with `is_redacted()`, a single-*value* predicate that matches its allowlist families with `re.search`. A run of six or more zeros, or a literal `XXX`/`REDACTED` anywhere in a body, made the whole page look already-redacted and skipped **every** content check for that entry — **209 of 750 committed fleet entries**, including the XB10 page holding the plaintext password. Without this, the fix above would not have closed the reported hole.

## Idempotency

Passes emitting a `PREFIX_<hash>` placeholder now skip already-redacted values, so re-sanitizing is a byte-level no-op even under the default random salt. Previously serials *grew*: pass 2's value class excluded `_`, so it matched only the `SERIAL` prefix of its own output and prepended a fresh hash each run.

Format-preserving passes (MAC, IPv4, IPv6, email) deliberately keep their previous behavior — their placeholders are valid-looking values in reserved ranges, and guarding them would pass real locally-administered MACs and real private IPs through unredacted. Two existing tests pin this.

## Verification

- 2549 unit + 26 integration tests pass, on both `.venv` and the `.venv-ci` matrix profile
- Combined coverage 96.08% (floor 90); all 7 per-module floors satisfied
- ruff, mypy, pre-commit all clean
- Across all 40 committed fleet captures the new rules touch **only** the real credentials and network names — zero collateral

## Note for downstream

`cable_modem_monitor` fixtures XB7 and XB10 still carry real default Wi-Fi passwords, and XB6 a household SSID. This release provides the tool that catches them; the pin bump and fixture sweep are what actually close the disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hviw7cm8y4sHJUyseL7H9M
